### PR TITLE
add guard for REST endpoint response of no endpoint

### DIFF
--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 			$response = get_site_transient( "git-updater-lite_{$this->file}" );
 			if ( ! $response ) {
 				$response = wp_remote_post( $url );
-				if ( is_wp_error( $response ) ) {
+				if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) === 404 ) {
 					return $response;
 				}
 


### PR DESCRIPTION
This happens if Git Updater is not installed/activated.

Fixes error that can show as currently api.fair.pm not set up with Git Updater