### PR TITLE
Revert https://github.com/fairpm/fair-plugin/pull/5

### DIFF
--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -113,7 +113,7 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 				return new \WP_Error( 'invalid_domain', 'Invalid update server domain', $this->update_server );
 			}
 			$url      = add_query_arg(
-				array( 'slug', $this->slug ),
+				array( 'slug' => $this->slug ),
 				sprintf( '%s/wp-json/git-updater/v1/update-api/', $this->update_server )
 			);
 			$response = get_site_transient( "git-updater-lite_{$this->file}" );

--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 			if ( empty( $this->update_server ) || is_wp_error( $this->update_server ) ) {
 				return new \WP_Error( 'invalid_domain', 'Invalid update server domain', $this->update_server );
 			}
-			$url      = "$this->update_server/git-updater/v1/update-api/?slug=$this->slug";
+			$url      = "$this->update_server/wp-json/git-updater/v1/update-api/?slug=$this->slug";
 			$response = get_site_transient( "git-updater-lite_{$this->file}" );
 			if ( ! $response ) {
 				$response = wp_remote_post( $url );

--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -112,7 +112,10 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 			if ( empty( $this->update_server ) || is_wp_error( $this->update_server ) ) {
 				return new \WP_Error( 'invalid_domain', 'Invalid update server domain', $this->update_server );
 			}
-			$url      = "$this->update_server/wp-json/git-updater/v1/update-api/?slug=$this->slug";
+			$url      = add_query_arg(
+				array( 'slug', $this->slug ),
+				sprintf( '%s/wp-json/git-updater/v1/update-api/', $this->update_server )
+			);
 			$response = get_site_transient( "git-updater-lite_{$this->file}" );
 			if ( ! $response ) {
 				$response = wp_remote_post( $url );


### PR DESCRIPTION
#5 will result in issues for any other users of the Git Updater Lite library and may not solve the issue if another instance of GUL is loaded before FAIR.

I believe the actual solution is to change the REST route on the `api.fair.pm` site so that the GUL library in its unmodified form will function for everyone. 