### PR TITLE
Assets: Fix code comments and add return type

### DIFF
--- a/inc/assets/namespace.php
+++ b/inc/assets/namespace.php
@@ -33,19 +33,17 @@ function get_emoji_base_url() : string {
 /**
  * Replace the CDN domain for regular Twemoji images.
  *
- * @param string $url The emoji URLs from s.w.org.
  * @return string Replaced URL.
  */
-function replace_emoji_url() {
+function replace_emoji_url() : string {
     return get_emoji_base_url() . '72x72/';
 }
 
 /**
  * Replace the CDN domain for regular Twemoji images.
  *
- * @param string $url The emoji URLs from s.w.org.
  * @return string Replaced URL.
  */
-function replace_emoji_svg_url() {
+function replace_emoji_svg_url() : string {
     return get_emoji_base_url() . 'svg/';
 }


### PR DESCRIPTION
Improves the assets function:

- Docs: `replace_emoji_url()` and `replace_emoji_svg_url()` don't have a parameter. 
- The return types are missing. We should add them to be consistent