### PR TITLE
Add `Domain Path` plugin header #17

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,6 +8,7 @@
  * Requires at least: 4.1
  * Requires PHP: 7.2.24
  * Text Domain: fair
+ * Domain Path: /languages
  * Update URI: https://api.fair.pm
  * GitHub Plugin URI: https://github.com/fairpm/fair-plugin
  * Primary Branch: main


### PR DESCRIPTION
Allows for the plugin to load translations from our own package, rather than from the global `languages` directory