### PR TITLE
Fix localization issues preventing strings from being translated

### DIFF
--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -385,7 +385,7 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 					<?php
 					printf(
 						/* translators: %s: theme name */
-						esc_html__( 'There is a new version of %s available.', 'git-updater-lite' ),
+						esc_html__( 'There is a new version of %s available.', 'fair' ),
 						esc_attr( $theme->name )
 					);
 						printf(
@@ -396,25 +396,25 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 					if ( ! empty( $current->response[ $theme->slug ]['package'] ) ) {
 						printf(
 						/* translators: 1: version number, 2: closing anchor tag, 3: update URL */
-							esc_html__( 'View version %1$s details%2$s or %3$supdate now%2$s.', 'git-updater-lite' ),
+							esc_html__( 'View version %1$s details%2$s or %3$supdate now%2$s.', 'fair' ),
 							$theme->remote_version = isset( $theme->remote_version ) ? esc_attr( $theme->remote_version ) : null,
 							'</a>',
 							sprintf(
 							/* translators: %s: theme name */
-								'<a aria-label="' . esc_html__( 'Update %s now', 'git-updater-lite' ) . '" id="update-theme" data-slug="' . esc_attr( $theme->slug ) . '" href="' . esc_url( $nonced_update_url ) . '">',
+								'<a aria-label="' . esc_html__( 'Update %s now', 'fair' ) . '" id="update-theme" data-slug="' . esc_attr( $theme->slug ) . '" href="' . esc_url( $nonced_update_url ) . '">',
 								esc_attr( $theme->name )
 							)
 						);
 					} else {
 						printf(
 						/* translators: 1: version number, 2: closing anchor tag, 3: update URL */
-							esc_html__( 'View version %1$s details%2$s.', 'git-updater-lite' ),
+							esc_html__( 'View version %1$s details%2$s.', 'fair' ),
 							$theme->remote_version = isset( $theme->remote_version ) ? esc_attr( $theme->remote_version ) : null,
 							'</a>'
 						);
 						printf(
 						/* translators: %s: opening/closing paragraph and italic tags */
-							esc_html__( '%1$sAutomatic update is unavailable for this theme.%2$s', 'git-updater-lite' ),
+							esc_html__( '%1$sAutomatic update is unavailable for this theme.%2$s', 'fair' ),
 							'<p><i>',
 							'</i></p>'
 						);

--- a/inc/version-check/namespace.php
+++ b/inc/version-check/namespace.php
@@ -98,7 +98,7 @@ function get_browser_check_response( string $agent ) {
 		],
 		'body' => json_encode( [
 			'platform' => _x( 'your platform', 'browser version check', 'fair' ),
-			'name' => __( 'your browser', 'browser version check', 'fair' ),
+			'name' => _x( 'your browser', 'browser version check', 'fair' ),
 			'version' => '',
 			'current_version' => '',
 			'upgrade' => ! $supported,


### PR DESCRIPTION
There are issue preventing localization of some strings:

* References to text-domain `git-updater-lite`
* Usage of localization with context that doesn't use `_x()` function

There are two references of strings without text-domain but those exist in core translations so are ok to use