### PR TITLE
Add composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules/
 *.bak
 /.vscode
+
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.vscode
 
 /vendor/
+
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "fairpm/fair-plugin",
+    "description": "Make your site more FAIR",
+	"version": "0.1.0",
+    "type": "wordpress-plugin",
+	"homepage": "https://github.com/fairpm/fair-plugin",
+	"readme": "README.md",
+	"keywords": [
+		"wordpress",
+		"plugin",
+		"FAIR"
+	],
+    "license": "GPLv2",
+    "authors": [
+        {
+            "name": "FAIR Contributors",
+			"email": "operations@fair.pm",
+			"homepage": "https://fair.pm"
+        }
+    ],
+	"support": {
+		"issues": "https://github.com/fairpm/fair-plugin/issues",
+		"source": "https://github.com/fairpm/fair-plugin/issues",
+		"docs": "https://github.com/fairpm/fair-plugin/blob/main/README.md"
+	},
+    "minimum-stability": "stable",
+    "require": {
+		"php": ">=7.4"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "fairpm/fair-plugin",
-    "description": "Make your site more FAIR",
+	"name": "fairpm/fair-plugin",
+	"description": "Make your site more FAIR",
 	"version": "0.1.0",
-    "type": "wordpress-plugin",
+	"type": "wordpress-plugin",
 	"homepage": "https://github.com/fairpm/fair-plugin",
 	"readme": "README.md",
 	"keywords": [
@@ -10,21 +10,21 @@
 		"plugin",
 		"FAIR"
 	],
-    "license": "GPLv2",
-    "authors": [
-        {
-            "name": "FAIR Contributors",
+	"license": "GPLv2",
+	"authors": [
+		{
+			"name": "FAIR Contributors",
 			"email": "operations@fair.pm",
 			"homepage": "https://fair.pm"
-        }
-    ],
+		}
+	],
 	"support": {
 		"issues": "https://github.com/fairpm/fair-plugin/issues",
 		"source": "https://github.com/fairpm/fair-plugin/issues",
 		"docs": "https://github.com/fairpm/fair-plugin/blob/main/README.md"
 	},
-    "minimum-stability": "stable",
-    "require": {
+	"minimum-stability": "stable",
+	"require": {
 		"php": ">=7.4"
 	}
 }


### PR DESCRIPTION
For WordPress projects managed through Composer, the addition of composer.json here allows them to more easily require the plugin.