### PR TITLE
Remove check on stable PHP versions from dashboard widget logic

### DIFF
--- a/inc/version-check/namespace.php
+++ b/inc/version-check/namespace.php
@@ -224,9 +224,9 @@ function check_php_version( string $version ) {
 
 	$cur_branch_data = $branches[ $cur_branch ];
 
-	if ( $cur_branch_data['state'] === 'stable' || $cur_branch_data['state'] === 'security' ) {
+	if ( $cur_branch_data['state'] === 'security' ) {
 		return [
-			// If we're on the stable or secure branches, the recommended version
+			// If we're on the security branches, the recommended version
 			// should be the latest version of this branch.
 			'recommended_version' => $cur_branch_data['latest'],
 			'minimum_version'     => MINIMUM_PHP,


### PR DESCRIPTION
Fixes #6 

Removes check on a `stable` PHP version to allow a pass-through to the remaining logic. The result is that anyone on a stable PHP version will not see the PHP Update Warning dashboard widget.