### PR TITLE
Keep generate-pot up to date with main

### DIFF
--- a/.github/workflows/generate-pot-pr.yml
+++ b/.github/workflows/generate-pot-pr.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           git fetch --all --prune
           git checkout generate-pot
-          git pull --no-rebase
+          git pull origin generate-pot --no-rebase
+          git merge origin/main --no-edit
 
       - name: Generate POT
         run: |


### PR DESCRIPTION
Fixes #56 by merging `main` into `generate-pot` before actual POT generation.