### PR TITLE
Add initial PHPUnit test infrastructure.

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,5 +3,8 @@
 .github/
 bin/
 node_modules/
+tests/
+phpunit.xml.dist
+composer.json
 .gitignore
 .distignore

--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,8 @@ bin/
 node_modules/
 tests/
 phpunit.xml.dist
+wp-tests-config-sample.php
 composer.json
+composer.lock
 .gitignore
 .distignore

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -1,0 +1,174 @@
+name: Run PHPUnit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Runs the PHPUnit tests for FAIR.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Sets up PHP.
+  # - Installs Composer dependencies.
+  # - Installs SVN.
+  # - Installs the test suite.
+  # - Runs the PHPUnit tests.
+  # - Ensures version-controlled files are not modified.
+  phpunit:
+    name: Run tests (WP ${{ matrix.wp-version }}, PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        wp-version: [ '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7' ]
+        exclude:
+          # PHP 8.4 exclusions
+          - wp-version: '6.6'
+            php-version: '8.4'
+          - wp-version: '6.5'
+            php-version: '8.4'
+          - wp-version: '6.4'
+            php-version: '8.4'
+          - wp-version: '6.3'
+            php-version: '8.4'
+          - wp-version: '6.2'
+            php-version: '8.4'
+          - wp-version: '6.1'
+            php-version: '8.4'
+          - wp-version: '6.0'
+            php-version: '8.4'
+          - wp-version: '5.9'
+            php-version: '8.4'
+          - wp-version: '5.8'
+            php-version: '8.4'
+          - wp-version: '5.7'
+            php-version: '8.4'
+          - wp-version: '5.6'
+            php-version: '8.4'
+          - wp-version: '5.5'
+            php-version: '8.4'
+          - wp-version: '5.4'
+            php-version: '8.4'
+
+          # PHP 8.3 exclusions
+          - wp-version: '6.3'
+            php-version: '8.3'
+          - wp-version: '6.2'
+            php-version: '8.3'
+          - wp-version: '6.1'
+            php-version: '8.3'
+          - wp-version: '6.0'
+            php-version: '8.3'
+          - wp-version: '5.9'
+            php-version: '8.3'
+          - wp-version: '5.8'
+            php-version: '8.3'
+          - wp-version: '5.7'
+            php-version: '8.3'
+          - wp-version: '5.6'
+            php-version: '8.3'
+          - wp-version: '5.5'
+            php-version: '8.3'
+          - wp-version: '5.4'
+            php-version: '8.3'
+
+          # PHP 8.2 exclusions
+          - wp-version: '6.0'
+            php-version: '8.2'
+          - wp-version: '5.9'
+            php-version: '8.2'
+          - wp-version: '5.8'
+            php-version: '8.2'
+          - wp-version: '5.7'
+            php-version: '8.2'
+          - wp-version: '5.6'
+            php-version: '8.2'
+          - wp-version: '5.5'
+            php-version: '8.2'
+          - wp-version: '5.4'
+            php-version: '8.2'
+
+          # PHP 8.1 exclusions
+          - wp-version: '5.8'
+            php-version: '8.1'
+          - wp-version: '5.7'
+            php-version: '8.1'
+          - wp-version: '5.6'
+            php-version: '8.1'
+          - wp-version: '5.5'
+            php-version: '8.1'
+          - wp-version: '5.4'
+            php-version: '8.1'
+
+          # PHP 8 exclusions
+          - wp-version: '5.8' # Should work, currently doesn't.
+            php-version: '8.0'
+          - wp-version: '5.7' # Should work, currently doesn't.
+            php-version: '8.0'
+          - wp-version: '5.6' # Introduced PHP 8 beta support. Should work, currently doesn't.
+            php-version: '8.0'
+          - wp-version: '5.5'
+            php-version: '8.0'
+          - wp-version: '5.4'
+            php-version: '8.0'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Setup MySQL with mysql_native_password
+        uses: shogo82148/actions-setup-mysql@v1
+        with:
+          mysql-version: ${{ matrix.wp-version >= '5.0' && '8.0' || '5.6' }}
+          my-cnf: |
+            bind_address=127.0.0.1
+            default-authentication-plugin=mysql_native_password
+          root-password: root
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          extensions: mysql, mysqli
+          tools: composer, wp-cli, phpunit:${{ matrix.wp-version < '5.1' && '6' || ( matrix.wp-version < '5.9' || matrix.php-version < '8.0' ) && '7' || '9' }}, phpunit-polyfills:^1.1.0
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Composer dependencies
+        run: composer install --optimize-autoloader --prefer-dist
+
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
+      - name: Install test suite
+        run: |
+          echo "WP_VERSION=${{ matrix.wp-version }}" >> $GITHUB_ENV
+          echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
+          echo "WP_TESTS_DIR=${{ runner.temp }}/wordpress-tests-lib" >> $GITHUB_ENV
+          echo "WP_CORE_DIR=${{ runner.temp }}/wordpress" >> $GITHUB_ENV
+          TMPDIR=${{ runner.temp }} bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
+
+      - name: Run PHPUnit tests
+        run: |
+          echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> ${{ runner.temp }}/wordpress-tests-lib/wp-tests-config.php
+          phpunit
+
+      - name: Ensure version-controlled files are not modified or deleted
+        run: git diff --exit-code

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -167,7 +167,6 @@ jobs:
 
       - name: Run PHPUnit tests
         run: |
-          echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> ${{ runner.temp }}/wordpress-tests-lib/wp-tests-config.php
           phpunit
 
       - name: Ensure version-controlled files are not modified or deleted

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Run PHPUnit tests
         run: |
+          echo "WP_TESTS_PHPUNIT_POLYFILLS_PATH=$HOME/.composer/vendor/yoast/phpunit-polyfills" >> $GITHUB_ENV
           phpunit
 
       - name: Ensure version-controlled files are not modified or deleted

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -167,7 +167,6 @@ jobs:
 
       - name: Run PHPUnit tests
         run: |
-          echo "WP_TESTS_PHPUNIT_POLYFILLS_PATH=$HOME/.composer/vendor/yoast/phpunit-polyfills" >> $GITHUB_ENV
           phpunit
 
       - name: Ensure version-controlled files are not modified or deleted

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Run PHPUnit tests
         run: |
+          echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> ${{ runner.temp }}/wordpress-tests-lib/wp-tests-config.php
           phpunit
 
       - name: Ensure version-controlled files are not modified or deleted

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /node_modules/
 *.bak
 /.vscode
+/vendor/
+.phpunit.result.cache
+phpunit.xml
+/tests/phpunit/cache
+/tests/phpunit/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 phpunit.xml
 /tests/phpunit/cache
 /tests/phpunit/coverage
+wp-tests-config.php

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,5 +6,8 @@
 	],
 	"mappings": {
 		"wp-content/plugins/plugin": "."
+	},
+	"config": {
+		"WP_TESTS_PHPUNIT_POLYFILLS_PATH": "./vendor/yoast/phpunit-polyfills"
 	}
 }

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		rm -rf $TMPDIR/wordpress-trunk/*
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		create_db
+	fi
+}
+
+install_wp
+install_test_suite
+install_db

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,60 @@
+{
+    "name": "fair/fair-plugin",
+    "description": "Make your site more FAIR.",
+    "type": "wordpress-plugin",
+    "license": "gpl-2.0-only",
+    "authors": [
+        {
+            "name": "FAIR Contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.24"
+    },
+    "require-dev": {
+        "yoast/phpunit-polyfills": "*",
+        "nimut/phpunit-merger": "*"
+    },
+    "config": {
+        "lock": false
+    },
+    "scripts": {
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "test:multisite": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit -c tests/phpunit/multisite.xml"
+        ],
+        "coverage:merge": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=coverage",
+            "@php ./vendor/bin/phpunit-merger coverage tests/phpunit/coverage/php --html tests/phpunit/coverage/html/full tests/phpunit/cache/full-cache.xml"
+        ],
+        "coverage:single": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=off",
+            "@putenv WP_TESTS_SKIP_INSTALL=0",
+            "@test --filter prime_test_suite",
+            "@putenv XDEBUG_MODE=coverage",
+            "@putenv WP_TESTS_SKIP_INSTALL=1",
+            "@test"
+        ],
+        "coverage:multisite": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=off",
+            "@putenv WP_TESTS_SKIP_INSTALL=0",
+            "@test:multisite --filter prime_test_suite",
+            "@putenv XDEBUG_MODE=coverage",
+            "@putenv WP_TESTS_SKIP_INSTALL=1",
+            "@test:multisite"
+        ],
+        "coverage:full": [
+            "Composer\\Config::disableProcessTimeout",
+            "@coverage:single",
+            "@coverage:multisite",
+            "@coverage:merge"
+        ]
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.24"
+        "php": ">=7.4"
     },
     "require-dev": {
         "yoast/phpunit-polyfills": "*",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
 		"@wordpress/env": "^10.22.0"
 	},
 	"scripts": {
-		"env": "wp-env"
+		"env": "wp-env",
+		"test:php:install-deps": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer install",
+		"test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer run test",
+		"test:php:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer run test:multisite",
+		"coverage:php:single": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer run coverage:single",
+		"coverage:php:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer run coverage:multisite",
+		"coverage:php:full": "wp-env run tests-cli --env-cwd=wp-content/plugins/plugin composer run coverage:full"
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutOutputDuringTests="true"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="default">
+			<directory suffix="Test.php">./tests/phpunit/tests/</directory>
+			<exclude>./tests/phpunit/tests/SampleTest.php</exclude>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>ms-required</group>
+		</exclude>
+	</groups>
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="false" cacheDirectory="./tests/phpunit/cache">
+		<include>
+			<directory suffix=".php">./inc</directory>
+		</include>
+		<report>
+			<text outputFile="php://stdout" showOnlySummary="true"/>
+			<html outputDirectory="./tests/phpunit/coverage/html/single-site"/>
+			<php outputFile="./tests/phpunit/coverage/php/single-site.php"/>
+		</report>
+	</coverage>
+</phpunit>

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Version: 0.1
  * Author: FAIR Contributors
  * License: GPLv2
- * Requires at least: 4.1
+ * Requires at least: 5.4
  * Requires PHP: 7.4
  * Text Domain: fair
  * Update URI: https://api.fair.pm

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: FAIR Contributors
  * License: GPLv2
  * Requires at least: 4.1
- * Requires PHP: 7.2.24
+ * Requires PHP: 7.4
  * Text Domain: fair
  * Update URI: https://api.fair.pm
  * GitHub Plugin URI: https://github.com/fairpm/fair-plugin

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -1,0 +1,64 @@
+# Instructions
+
+## Setting up the dev environment
+
+### Option 1: wp-env
+1. Ensure Docker is installed and running.
+2. Run `npm i`
+3. Run `npm run env start`
+4. Run `npm run test:php:install-deps`
+5. Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.
+
+### Option 2: Local web server and MySQL database:
+- Run `composer install`
+- Create a new database using `mysql -u<username> -p` -> `CREATE DATABASE <database_name>;` -> `exit;`
+  - Note: Don't use an existing database - the database is reset before every test run by default.
+- Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.
+- Ensure that `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and `DB_HOST` in `wp-tests-config.php` match your setup.
+- Run `./bin/install-wp-tests.sh` with the appropriate credentials.
+
+## Running PHPUnit tests
+
+### Single Site
+```
+npm run test:php
+```
+If you're not using wp-env, you can just run `composer run test`.
+
+### Multisite
+```
+npm run test:php:multisite
+```
+If you're not using wp-env, you can just run `composer run test:multisite`.
+
+## Running PHPUnit tests with line coverage
+
+First, start the environment with xDebug:
+```
+npm run env start -- --xdebug=coverage
+```
+If you're not using wp-env, make sure the xDebug PHP module is installed and enabled.
+
+### Single Site
+```
+npm run coverage:php:single
+```
+If you're not using wp-env, you can just run `composer run coverage:single`.
+
+A coverage report will be available at `/tests/phpunit/coverage/html/single-site`.
+
+### Multisite
+```
+npm run coverage:php:multisite
+```
+If you're not using wp-env, you can just run `composer run coverage:multisite`.
+
+A coverage report will be available at `/tests/phpunit/coverage/html/multisite`.
+
+### Single Site and Multisite
+```
+npm run coverage:php:full
+```
+If you're not using wp-env, you can just run `composer run coverage:full`.
+
+A merged coverage report will be available at `/tests/phpunit/coverage/html/full`.

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -3,11 +3,11 @@
 ## Setting up the dev environment
 
 ### Option 1: wp-env
-1. Ensure Docker is installed and running.
-2. Run `npm i`
-3. Run `npm run env start`
-4. Run `npm run test:php:install-deps`
-5. Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.
+1. Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.
+2. Ensure Docker is installed and running.
+3. Run `npm i`
+4. Run `npm run env start`
+5. Run `npm run test:php:install-deps`
 
 ### Option 2: Local web server and MySQL database:
 - Run `composer install`

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package FAIR
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( __DIR__, 2 ) . '/plugin.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -17,6 +17,8 @@ define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.p
 $_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
 if ( false !== $_phpunit_polyfills_path ) {
 	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+} else {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills' );
 }
 
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,14 +11,16 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.php' );
+if ( ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) && file_exists( dirname( __DIR__, 2 ) . '/wp-tests-config.php' ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.php' );
+}
 
 // Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
 $_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
 if ( false !== $_phpunit_polyfills_path ) {
 	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
 } else {
-	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills' );
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills/' );
 }
 
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,6 +11,8 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.php' );
+
 // Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
 $_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
 if ( false !== $_phpunit_polyfills_path ) {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -15,13 +15,7 @@ if ( ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) && file_exists( dirname( __DIR__, 
 	define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.php' );
 }
 
-// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
-$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
-if ( false !== $_phpunit_polyfills_path ) {
-	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
-} else {
-	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills/' );
-}
+define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills/' );
 
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
 	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -15,8 +15,6 @@ if ( ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) && file_exists( dirname( __DIR__, 
 	define( 'WP_TESTS_CONFIG_FILE_PATH', dirname( __DIR__, 2 ) . '/wp-tests-config.php' );
 }
 
-define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills/' );
-
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
 	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="./bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertDeprecationsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<!-- Default test suite to run all tests. -->
+		<testsuite name="default">
+			<directory suffix=".php">./tests</directory>
+			<exclude>./tests/SampleTest.php</exclude>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>ms-excluded</group>
+		</exclude>
+	</groups>
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="false" cacheDirectory="./cache">
+		<include>
+			<directory suffix=".php">../../inc</directory>
+		</include>
+		<report>
+			<text outputFile="php://stdout" showOnlySummary="true"/>
+			<html outputDirectory="./coverage/html/multisite"/>
+			<php outputFile="./coverage/php/multisite.php"/>
+		</report>
+	</coverage>
+</phpunit>

--- a/tests/phpunit/tests/SampleTest.php
+++ b/tests/phpunit/tests/SampleTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File structure
+ * --------------
+ * - Each <Module> should have its own directory.
+ * - Each <FunctionUnderTest> should have its own file.
+ *
+ * Formats
+ * -------
+ * - File name: tests/Module/FunctionNameTest.php
+ * - Class name: FunctionNameTest
+ * - Method name: test_should(_not)_do_<something>[_when_<condition>]()
+ *
+ * Coverage
+ * --------
+ * - @covers tags should be placed at the class level and target the FunctionUnderTest.
+ * - Since each <FunctionUnderTest> has its own test class, @coversDefaultClass should not be used.
+ *
+ * Using Assertions
+ * ----------------
+ * See https://docs.phpunit.de/en/10.5/assertions.html for available assertions.
+ *
+ * The strictest possible assertion should always be used.
+ *
+ * If multiple assertions are used in the same test method, a final '$message' argument should
+ * be passed to each assertion to provide context should the assertion fail. This can help
+ * to identify exactly when and how something isn't working as expected.
+ *
+ * Testing multiple values
+ * -----------------------
+ * When testing multiple values, a data provider method should be used.
+ *
+ * - Data provider methods should be prefixed with "data_".
+ * - Datasets and their properties should be named.
+ */
+
+/**
+ * Tests for FAIR\Namespace\FunctionUnderTest().
+ *
+ * @covers FAIR\Namespace\FunctionUnderTest
+ */
+class SampleTest extends WP_UnitTestCase {
+	/**
+	 * Tests that true is true.
+	 */
+	public function test_should_return_true() {
+		$actual = true;
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests that false is not true.
+	 */
+	public function test_should_not_think_false_is_true() {
+		$actual = false;
+
+		$this->assertNotTrue( $actual );
+	}
+
+	/**
+	 * Tests that multiple values are not true.
+	 *
+	 * @dataProvider data_not_true_values
+	 *
+	 * @param mixed $value The value to test.
+	 */
+	public function test_should_not_be_true( $value ) {
+		$this->assertNotTrue( $value );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_not_true_values() {
+		return [
+			// Think: "Running test with <dataset name>".
+			'(int) 1' => [
+				'value' => 1,
+			],
+			'an empty array' => [
+				'value' => [],
+			],
+			'a populated array' => [
+				'value' => [ 'populated' ],
+			],
+			// And so on.
+		];
+	}
+}

--- a/wp-tests-config-sample.php
+++ b/wp-tests-config-sample.php
@@ -1,7 +1,11 @@
 <?php
 
-/* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
-define( 'ABSPATH', dirname( __DIR__, 3 ) . '/');
+/* Path to the WordPress Core codebase. */
+if ( file_exists( dirname( __DIR__, 2 ) . '/wp-load.php' ) ) {
+	define( 'ABSPATH', dirname( __DIR__, 2 ) . '/');
+} elseif ( file_exists( dirname( __DIR__, 3 ) . '/wp-load.php' ) ) {
+	define( 'ABSPATH', dirname( __DIR__, 3 ) . '/');
+}
 
 // Test with multisite enabled: (previously -m)
 // define( 'WP_TESTS_MULTISITE', true );

--- a/wp-tests-config.php
+++ b/wp-tests-config.php
@@ -1,0 +1,39 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
+define( 'ABSPATH', dirname( __DIR__, 3 ) . '/');
+
+// Test with multisite enabled: (previously -m)
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs: (previously -f)
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode on (previously -d)
+// define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', 'tests-wordpress' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', 'password' );
+define( 'DB_HOST', 'tests-mysql' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix  = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );


### PR DESCRIPTION
This adds an initial setup for PHPUnit tests.

## Changes
- WordPress Core's test suite installer script.
  - `./bin/install-wp-tests.sh`
- A PHPUnit bootstrap file.
  - `./tests/phpunit/bootstrap.php`
- A sample tests configuration file.
  - `./wp-tests-config-sample.php`
- Single-site and Multisite configuration files.
  - `./phpunit.xml.dist` and `./tests/phpunit/multisite.xml` respectively
- A sample test file with some test standards/conventions I'm suggesting.
  - `./tests/phpunit/tests/SampleTest.php`
- Composer scripts for running tests, single-site and multisite coverage reports, and merging said reports into one.
- NPM scripts (using wp-env) for running tests, single-site and multisite coverage reports, and merging said reports into one.

## Additional changes to the plugin
- Bumps the minimum PHP version to 7.4.
  - The existing wp-env configuriation runs PHP 7.4, and there are various features (arrow functions, etc.) that are already in the codebase. PHP 7.2.24 is too early for some of these.
- Bumps the minimum WordPress version to 5.4.
  - WordPress 5.4 is the version after initial PHP 7.4 support was added.
  - Note: This is likely to be bumped even higher.

---

# Instructions

## Setting up the dev environment

### Option 1: wp-env
1. Ensure Docker is installed and running.
2. Run `npm i`
3. Run `npm run env start`
4. Run `npm run test:php:install-deps`
5. Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.

### Option 2: Local web server and MySQL database:
- Run `composer install`
- Create a new database using `mysql -u<username> -p` -> `CREATE DATABASE <database_name>;` -> `exit;`
  - Note: Don't use an existing database - the database is reset before every test run by default.
- Copy `wp-tests-config-sample.php` to `wp-tests-config.php`.
- Ensure that `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and `DB_HOST` in `wp-tests-config.php` match your setup.
- Run `./bin/install-wp-tests.sh` with the appropriate credentials.

## Running PHPUnit tests

### Single Site
```
npm run test:php
```
If you're not using wp-env, you can just run `composer run test`.

### Multisite
```
npm run test:php:multisite
```
If you're not using wp-env, you can just run `composer run test:multisite`.

## Running PHPUnit tests with line coverage

First, start the environment with xDebug:
```
npm run env start -- --xdebug=coverage
```
If you're not using wp-env, make sure the xDebug PHP module is installed and enabled.

### Single Site
```
npm run coverage:php:single
```
If you're not using wp-env, you can just run `composer run coverage:single`.

A coverage report will be available at `/tests/phpunit/coverage/html/single-site`.

### Multisite
```
npm run coverage:php:multisite
```
If you're not using wp-env, you can just run `composer run coverage:multisite`.

A coverage report will be available at `/tests/phpunit/coverage/html/multisite`.

### Single Site and Multisite
```
npm run coverage:php:full
```
If you're not using wp-env, you can just run `composer run coverage:full`.

A merged coverage report will be available at `/tests/phpunit/coverage/html/full`.

This PR only adds a sample test for guidance, which will be ignored when running the test suite. You'll know the above works if PHPUnit runs and "No tests executed!" is displayed.

---

Fixes #59 