### PR TITLE
Support ClassicPress News widget

### DIFF
--- a/inc/dashboard-widgets/namespace.php
+++ b/inc/dashboard-widgets/namespace.php
@@ -10,7 +10,7 @@ const EVENTS_API = 'https://api.fair.pm/fair/v1/events';
  * Bootstrap.
  */
 function bootstrap() {
-	if ( function_exists( 'classicpress_version' ) ) {
+	if ( ! function_exists( 'wp_print_community_events_markup' ) ) {
 		return;
 	}
 	add_action( 'wp_ajax_get-community-events', __NAMESPACE__ . '\\get_community_events_ajax', 0 );

--- a/inc/dashboard-widgets/namespace.php
+++ b/inc/dashboard-widgets/namespace.php
@@ -10,6 +10,7 @@ const EVENTS_API = 'https://api.fair.pm/fair/v1/events';
  * Bootstrap.
  */
 function bootstrap() {
+	// Support existing software like ClassicPress, which removes this feature.
 	if ( ! function_exists( 'wp_print_community_events_markup' ) ) {
 		return;
 	}

--- a/inc/dashboard-widgets/namespace.php
+++ b/inc/dashboard-widgets/namespace.php
@@ -10,6 +10,9 @@ const EVENTS_API = 'https://api.fair.pm/fair/v1/events';
  * Bootstrap.
  */
 function bootstrap() {
+	if ( function_exists( 'classicpress_version' ) ) {
+		return;
+	}
 	add_action( 'wp_ajax_get-community-events', __NAMESPACE__ . '\\get_community_events_ajax', 0 );
 	remove_action( 'wp_ajax_get-community-events', 'wp_ajax_get_community_events', 1 );
 


### PR DESCRIPTION
[ClassicPress](https://www.classicpress.net/) is a fork of WordPress, without blocks.

Since ClassicPress have it's own news system, this prevents a fatal error in the dashboard.
`wp_print_community_events_markup()` is not present in ClassicPress as the Community Events widget.

## Before

<img width="635" alt="image" src="https://github.com/user-attachments/assets/72e61eef-2250-4a66-b3ae-2671b9d51bf6" />


## After

<img width="940" alt="image" src="https://github.com/user-attachments/assets/221d2774-2d68-4e02-9098-3aacc96fd78b" />
