### PR TITLE
Switch escaping to `aria-label` and change text order.

### DIFF
--- a/inc/updater/class-lite.php
+++ b/inc/updater/class-lite.php
@@ -404,7 +404,7 @@ if ( ! class_exists( 'Fragen\\Git_Updater\\Lite' ) ) {
 							'</a>',
 							sprintf(
 							/* translators: %s: theme name */
-								'<a aria-label="' . esc_html__( 'Update %s now', 'fair' ) . '" id="update-theme" data-slug="' . esc_attr( $theme->slug ) . '" href="' . esc_url( $nonced_update_url ) . '">',
+								'<a aria-label="' . esc_attr__( '%s: update now', 'fair' ) . '" id="update-theme" data-slug="' . esc_attr( $theme->slug ) . '" href="' . esc_url( $nonced_update_url ) . '">',
 								esc_attr( $theme->name )
 							)
 						);


### PR DESCRIPTION
`aria-label` should be escaped as an attribute, and the text order needs to match the visual text, so that voice command users can speak the command as they see it and be able to trigger the button.

Signed-off-by: Joe Dolson <design@joedolson.com>