### PR TITLE
Add `.gitattributes` and exclude other development files.

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,6 +8,8 @@ phpunit.xml.dist
 wp-tests-config-sample.php
 composer.json
 composer.lock
+package.json
+package-lock.json
 .wp-env.json
 .gitignore
 .gitattributes

--- a/.distignore
+++ b/.distignore
@@ -8,5 +8,8 @@ phpunit.xml.dist
 wp-tests-config-sample.php
 composer.json
 composer.lock
+.wp-env.json
 .gitignore
+.gitattributes
 .distignore
+.editorconfig

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@ phpunit.xml.dist export-ignore
 wp-tests-config-sample.php export-ignore
 composer.json export-ignore
 composer.lock export-ignore
+.wp-env.json export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
 .distignore export-ignore
+.editorconfig export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+
+/.git export-ignore
+/.github export-ignore
+/bin export-ignore
+/node_modules export-ignore
+/tests export-ignore
+phpunit.xml.dist export-ignore
+wp-tests-config-sample.php export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+.distignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@ phpunit.xml.dist export-ignore
 wp-tests-config-sample.php export-ignore
 composer.json export-ignore
 composer.lock export-ignore
+package.json export-ignore
+package-lock.json export-ignore
 .wp-env.json export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
This adds a `.gitattributes` file so that packages created using `git archive -o` will correctly exclude files that should not be included in the release package. `.distignore` has been updated to include `.gitattributes`. Additional development files, such as `.wp-env.json` and `.editorconfig` have also been added to both ignore lists.

Fixes #102 