### PR TITLE
Use "fair-plugin" in the bundled distribution script.

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build project
-        run: git archive -o /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip --prefix=${{ github.event.repository.name }}/ ${{ steps.tag.outputs.tag }}
+        run: git archive -o /tmp/fair-${{ steps.tag.outputs.tag }}.zip --prefix=fair/ ${{ steps.tag.outputs.tag }}
 
       - name: Create WP distribution files
         run: bin/bundle.sh
@@ -34,10 +34,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+            /tmp/fair-${{ steps.tag.outputs.tag }}.zip
             /tmp/fair-dist/*
 
       - name: Build provenance attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+          subject-path: /tmp/fair-${{ steps.tag.outputs.tag }}.zip

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build project
-        run: git archive -o /tmp/fair-${{ steps.tag.outputs.tag }}.zip --prefix=fair/ ${{ steps.tag.outputs.tag }}
+        run: git archive -o /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip --prefix=${{ github.event.repository.name }}/ ${{ steps.tag.outputs.tag }}
 
       - name: Create WP distribution files
         run: bin/bundle.sh
@@ -34,10 +34,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            /tmp/fair-${{ steps.tag.outputs.tag }}.zip
+            /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
             /tmp/fair-dist/*
 
       - name: Build provenance attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: /tmp/fair-${{ steps.tag.outputs.tag }}.zip
+          subject-path: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip

--- a/bin/bundle.sh
+++ b/bin/bundle.sh
@@ -15,8 +15,8 @@ touch /tmp/fair-dist/SHA384SUMS
 
 # Bundle our plugin first.
 [ -d /tmp/fair-temp ] && rm -rf /tmp/fair-temp
-mkdir -p /tmp/fair-temp/wordpress/wp-content/plugins/fair
-rsync -a --exclude-from="$SCRIPT_DIR/../.distignore" "$SCRIPT_DIR/.." /tmp/fair-temp/wordpress/wp-content/plugins/fair
+mkdir -p /tmp/fair-temp/wordpress/wp-content/plugins/fair-plugin
+rsync -a --exclude-from="$SCRIPT_DIR/../.distignore" "$SCRIPT_DIR/.." /tmp/fair-temp/wordpress/wp-content/plugins/fair-plugin
 
 echo "Fetching WordPress version data" >&2
 VERSION_DATA=$(curl -s https://api.wordpress.org/core/version-check/1.7/)


### PR DESCRIPTION
This replaces instances of `fair` with `fair-plugin` in the `bin/bundle.sh` script for consistent naming of the package and directory.

Fixes #104 