### PR TITLE
Privacy Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ FAIR is built to reduce external dependencies and keep your site as self-contain
 
 In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/). These services include:
 
-* WordPress Events - sourced from [The WP World](https://thewp.world)
+* WordPress Events - Retrieved from [The WP World](https://thewp.world) hourly and then cached on our servers. No user data is sent to The WP World.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ FAIR is built to reduce external dependencies and keep your site as self-contain
 * Alerting Ping services when a post is published is handled by [IndexNow](https://www.indexnow.org).
 * Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
 * PHP versions are provided by [php.net](https://php.net)
-* Twemoji (emoji assets) are managed by [jsDeliver](https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/)
+* Twemoji (emoji assets) are retrieved by [jsDeliver](https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/)
 
 In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/). These services include:
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 
 FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
 
-* Alerting Ping services when a post is published is handled by [IndexNow](https://www.indexnow.org).
+* Search engine pings when a post is published are handled by [IndexNow](https://www.indexnow.org).
 * Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
 * PHP versions are provided by [php.net](https://php.net)
 * Twemoji (emoji assets) are retrieved by [jsDeliver](https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/)
 
-In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/). These services include:
+In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/); additionally, [the server itself is open source](https://github.com/fairpm/server). These services include:
 
-* WordPress Events (`https://api.fair.pm/fair/v1/events`)- Retrieved from [The WP World](https://thewp.world) hourly and then cached on our servers. No user data is sent to The WP World.
+* WordPress Events (`https://api.fair.pm/fair/v1/events`) - Retrieved from [The WP World](https://thewp.world) hourly and then cached on our servers. No user data is sent to The WP World.
+* WordPress Planet/News (`https://planet.fair.pm/atom.xml`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 
 ### Data Privacy
 
+* See Also: [Linux Foundation Projects Privacy Policy](https://lfprojects.org/policies/privacy-policy/)
+
 FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
 
 * Ping Services when a post is published is handled by [IndexNow](https://www.indexnow.org).
-* The list of WordPress Events shown on your WP Admin Dashboard is retrieved from [The WP World](https://thewp.world)
 * Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
+
+In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/). These services include:
+
+* WordPress Events - sourced from [The WP World](https://thewp.world)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 
 FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
 
-* Ping Services when a post is published is handled by [IndexNow](https://www.indexnow.org).
+* Alerting Ping services when a post is published is handled by [IndexNow](https://www.indexnow.org).
 * Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
+* PHP versions are provided by [php.net](https://php.net)
+* Twemoji (emoji assets) are managed by [jsDeliver](https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/)
 
 In addition we self-host certain features that could not be properly protected on our API servers as an intermediary. All data collected from FAIR servers fall under the [Linux Foundation Policies and Terms of Use for Hosted Projects](https://lfprojects.org/policies/hosted-project-tools-terms-of-use/). These services include:
 
-* WordPress Events - Retrieved from [The WP World](https://thewp.world) hourly and then cached on our servers. No user data is sent to The WP World.
+* WordPress Events (`https://api.fair.pm/fair/v1/events`)- Retrieved from [The WP World](https://thewp.world) hourly and then cached on our servers. No user data is sent to The WP World.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
 
 * Search engine pings when a post is published are handled by [IndexNow](https://www.indexnow.org).
-* Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
+* Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/) (or other mirror as configured).
 * PHP versions are provided by [php.net](https://php.net)
 * Twemoji (emoji assets) are retrieved by [jsDeliver](https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 * Media features provided by OpenVerse are disabled, pending discussion and work by the FAIR working group
 * Ping services are configured to use IndexNow in place of Pingomatic
 
+### Data Privacy
+
+FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
+
+* Ping Services when a post is published is handled by [IndexNow](https://www.indexnow.org).
+* The list of WordPress Events shown on your WP Admin Dashboard is powered by [The WP World](https://thewp.world)
+* Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on contributing.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 FAIR is built to reduce external dependencies and keep your site as self-contained as possible. However, some essential features require connecting to remote services in order to function correctly. This section details which features involve remote requests, what data may be transmitted, and the specific third-party providers involved. Review the list below to understand exactly where and why your site may communicate with external endpoints.
 
 * Ping Services when a post is published is handled by [IndexNow](https://www.indexnow.org).
-* The list of WordPress Events shown on your WP Admin Dashboard is powered by [The WP World](https://thewp.world)
+* The list of WordPress Events shown on your WP Admin Dashboard is retrieved from [The WP World](https://thewp.world)
 * Installation and updates of all WordPress Packages (core, plugins, themes) are via [AspireCloud from AspirePress](https://aspirepress.org/)
 
 ## Contributing


### PR DESCRIPTION
The readme was lacking a privacy section which, given the nature of the work, is necessary.

Any time there's a service we call, we HAVE to document it in the readme. No excuses.