### PR TITLE
Introduce a Git hook to help ensure commits are signed-off

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Ensure the commit is signed-off by the author.
+if ! grep -q '^Signed-off-by: ' "$1"; then
+	echo >&2 "Commit message must be signed off by the author."
+	exit 1
+fi
+
+# Catch duplicate Signed-off-by lines.
+test "" = "$(grep '^Signed-off-by: ' "$1" |
+	 sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d')" || {
+	echo >&2 Duplicate Signed-off-by lines.
+	exit 1
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ $ git commit -s -m 'My commit message.'
 
 **Please Note:** This is adding a _sign-off_ to the commit, which is not the same as *signing* your commits (which involves GPG keys).
 
+Alternatively, run `composer run setup` to install a git hook which will automatically reject your commits if they are not signed off.
+
 ## Development Environment
 
 This plugin is ready to use with wp-env for local development, with a default configuration included in the repository. `npm run env` is an alias for `wp-env`:

--- a/bin/install-git-hooks.sh
+++ b/bin/install-git-hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+#
+# Create our distribution zips.
+
+# Create a link to our commit-msg hook.
+ln -s -f ../../.githooks/commit-msg .git/hooks/commit-msg
+echo "Installed commit-msg hook."

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "lock": false
     },
     "scripts": {
+		"setup": [
+			"./bin/install-git-hooks.sh"
+		],
         "test": [
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit"


### PR DESCRIPTION
Adds a commit-msg hook that checks for the presence of the "Signed-off-by: " string in the commit message and rejects the commit when it's missing. Additonally, it checks if there is more than one "Signed-off-by: " string and rejects that too (this is from the default hook sample).

To make life easier for contributors a composer script is added so that running `composer run setup` runs a simple bash script (`bin/install-git-hooks.sh`) which adds a symlink from the committed git hook to `.git/hooks/commit-msg`.

Finally, the docs are updated to let people know they can install the git hook. I opted to leave the manual instructions for signing commits in place, as it's helpful for understanding as well.