### PR TITLE
add Git Updater Lite based updater for packages

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,6 +29,9 @@ function bootstrap() {
 	Default_Repo\bootstrap();
 	Disable_Openverse\bootstrap();
 	Importers\bootstrap();
+	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
+		Packages\Upgrader\bootstrap();
+	}
 	Pings\bootstrap();
 	Salts\bootstrap();
 	Settings\bootstrap();

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,12 +29,12 @@ function bootstrap() {
 	Default_Repo\bootstrap();
 	Disable_Openverse\bootstrap();
 	Importers\bootstrap();
-	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
-		Packages\Upgrader\bootstrap();
-	}
 	Pings\bootstrap();
 	Salts\bootstrap();
 	Settings\bootstrap();
+	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
+		Updater\bootstrap();
+	}
 	User_Notification\bootstrap();
 	Version_Check\bootstrap();
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -32,9 +32,7 @@ function bootstrap() {
 	Pings\bootstrap();
 	Salts\bootstrap();
 	Settings\bootstrap();
-	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
-		Updater\bootstrap();
-	}
+	Updater\bootstrap();
 	User_Notification\bootstrap();
 	Version_Check\bootstrap();
 

--- a/inc/packages/upgrader/namespace.php
+++ b/inc/packages/upgrader/namespace.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace FAIR\Packages\Upgrader;
+
+use Fragen\Git_Updater;
+use stdClass;
+
+/**
+ * Exit if called directly.
+ */
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+function bootstrap() {
+	add_action( 'init', __NAMESPACE__ . '\\init' );
+}
+
+/**
+ * Gather all plugins/themes with data in Update URI and DID header.
+ *
+ * @return stdClass
+ */
+function init() {
+	/** @var array */
+	$package_arr = array();
+
+	// Seems to be required for PHPUnit testing on GitHub workflow.
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$plugin_path = trailingslashit( WP_PLUGIN_DIR );
+	$plugins     = get_plugins();
+	foreach ( $plugins as $file => $plugin ) {
+		$update_uri = $plugin['UpdateURI'];
+		$plugin_id  = get_file_data( $plugin_path . $file, array( 'PluginID' => 'Plugin ID' ) )['PluginID'];
+
+		if ( ! empty( $update_uri ) && ! empty( $plugin_id ) ) {
+			$package_arr[] = $plugin_path . $file;
+		}
+	}
+
+	$theme_path = WP_CONTENT_DIR . '/themes/';
+	$themes     = wp_get_themes();
+	foreach ( $themes as $file => $theme ) {
+		$update_uri = $theme->get( 'UpdateURI' );
+		$theme_id   = get_file_data( $theme_path . $file . '/style.css', array( 'ThemeID' => 'Theme ID' ) )['ThemeID'];
+
+		if ( ! empty( $update_uri ) && ! empty( $theme_id ) ) {
+			$package_arr[] = $theme_path . $file . '/style.css';
+		}
+	}
+
+	run( $package_arr );
+}
+
+/**
+ * Run Git Updater Lite for potential packages.
+ *
+ * @return void
+ */
+function run( $package_arr ) {
+	foreach ( $package_arr as $package ) {
+		( new Git_Updater\Lite( $package ) )->run();
+	}
+}

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -23,7 +23,7 @@ function bootstrap() {
  */
 function init() {
 	/** @var array */
-	$package_arr = array();
+	$package_arr = [];
 
 	// Seems to be required for PHPUnit testing on GitHub workflow.
 	if ( ! function_exists( 'get_plugins' ) ) {
@@ -34,7 +34,7 @@ function init() {
 	$plugins     = get_plugins();
 	foreach ( $plugins as $file => $plugin ) {
 		$update_uri = $plugin['UpdateURI'];
-		$plugin_id  = get_file_data( $plugin_path . $file, array( 'PluginID' => 'Plugin ID' ) )['PluginID'];
+		$plugin_id  = get_file_data( $plugin_path . $file, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
 
 		if ( ! empty( $update_uri ) && ! empty( $plugin_id ) ) {
 			$package_arr[] = $plugin_path . $file;
@@ -45,7 +45,7 @@ function init() {
 	$themes     = wp_get_themes();
 	foreach ( $themes as $file => $theme ) {
 		$update_uri = $theme->get( 'UpdateURI' );
-		$theme_id   = get_file_data( $theme_path . $file . '/style.css', array( 'ThemeID' => 'Theme ID' ) )['ThemeID'];
+		$theme_id   = get_file_data( $theme_path . $file . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];
 
 		if ( ! empty( $update_uri ) && ! empty( $theme_id ) ) {
 			$package_arr[] = $theme_path . $file . '/style.css';

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -34,9 +34,12 @@ function init() {
 	$plugins     = get_plugins();
 	foreach ( $plugins as $file => $plugin ) {
 		$update_uri = $plugin['UpdateURI'];
-		$plugin_id  = get_file_data( $plugin_path . $file, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
+		if ( empty( $update_uri ) ) {
+			continue;
+		}
+		$plugin_id = get_file_data( $plugin_path . $file, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
 
-		if ( ! empty( $update_uri ) && ! empty( $plugin_id ) ) {
+		if ( ! empty( $plugin_id ) ) {
 			$package_arr[] = $plugin_path . $file;
 		}
 	}
@@ -45,9 +48,12 @@ function init() {
 	$themes     = wp_get_themes();
 	foreach ( $themes as $file => $theme ) {
 		$update_uri = $theme->get( 'UpdateURI' );
-		$theme_id   = get_file_data( $theme_path . $file . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];
+		if ( empty( $update_uri ) ) {
+			continue;
+		}
+		$theme_id = get_file_data( $theme_path . $file . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];
 
-		if ( ! empty( $update_uri ) && ! empty( $theme_id ) ) {
+		if ( ! empty( $theme_id ) ) {
 			$package_arr[] = $theme_path . $file . '/style.css';
 		}
 	}

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -3,7 +3,6 @@
 namespace FAIR\Updater;
 
 use Fragen\Git_Updater;
-use stdClass;
 
 /**
  * Exit if called directly.

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -35,8 +35,7 @@ function init() {
 	$plugin_path = trailingslashit( WP_PLUGIN_DIR );
 	$plugins     = get_plugins();
 	foreach ( $plugins as $file => $plugin ) {
-		$update_uri = $plugin['UpdateURI'];
-		if ( empty( $update_uri ) ) {
+		if ( empty( $plugin['UpdateURI'] ) ) {
 			continue;
 		}
 		$plugin_id = get_file_data( $plugin_path . $file, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
@@ -49,8 +48,7 @@ function init() {
 	$theme_path = WP_CONTENT_DIR . '/themes/';
 	$themes     = wp_get_themes();
 	foreach ( $themes as $file => $theme ) {
-		$update_uri = $theme->get( 'UpdateURI' );
-		if ( empty( $update_uri ) ) {
+		if ( empty( $theme->get( 'UpdateURI' ) ) ) {
 			continue;
 		}
 		$theme_id = get_file_data( $theme_path . $file . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -12,6 +12,9 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+/**
+ * Bootstrap
+ */
 function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\init' );
 }

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace FAIR\Packages\Upgrader;
+namespace FAIR\Updater;
 
 use Fragen\Git_Updater;
 use stdClass;

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -13,7 +13,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**
- * Bootstrap
+ * Bootstrap.
  */
 function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\init' );

--- a/plugin.php
+++ b/plugin.php
@@ -27,10 +27,10 @@ require_once __DIR__ . '/inc/dashboard-widgets/namespace.php';
 require_once __DIR__ . '/inc/default-repo/namespace.php';
 require_once __DIR__ . '/inc/disable-openverse/namespace.php';
 require_once __DIR__ . '/inc/importers/namespace.php';
-require_once __DIR__ . '/inc/packages/upgrader/namespace.php';
 require_once __DIR__ . '/inc/pings/namespace.php';
 require_once __DIR__ . '/inc/salts/namespace.php';
 require_once __DIR__ . '/inc/settings/namespace.php';
+require_once __DIR__ . '/inc/updater/namespace.php';
 require_once __DIR__ . '/inc/user-notification/namespace.php';
 require_once __DIR__ . '/inc/version-check/namespace.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/inc/dashboard-widgets/namespace.php';
 require_once __DIR__ . '/inc/default-repo/namespace.php';
 require_once __DIR__ . '/inc/disable-openverse/namespace.php';
 require_once __DIR__ . '/inc/importers/namespace.php';
+require_once __DIR__ . '/inc/packages/upgrader/namespace.php';
 require_once __DIR__ . '/inc/pings/namespace.php';
 require_once __DIR__ . '/inc/salts/namespace.php';
 require_once __DIR__ . '/inc/settings/namespace.php';


### PR DESCRIPTION
This adds an upgrade process for any repository based packages. A repository package is defined as having the following requirements.

**Requirements**
- an `Update URI` header pointing to the domain of record for the package.
 - a `Plugin ID` or `Theme ID` header containing the DID, based upon https://github.com/fairpm/fair-protocol/blob/main/docs/publishing.md

Use the existing `class-lite.php`. This should integrate well with #71.

Fixes #132 