### PR TITLE
Declare the plugin as network-only

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -12,6 +12,7 @@
  * Update URI: https://api.fair.pm
  * GitHub Plugin URI: https://github.com/fairpm/fair-plugin
  * Primary Branch: main
+ * Network: true
  */
 
 namespace FAIR;


### PR DESCRIPTION
There is no reason to activate FAIR on individual sites within a multisite installation. This change adds the `Network: true` header so the plugin can only be network-activated on a Multisite installation.

This has no effect on single-site installations.