### PR TITLE
Increase timeout when getting metadata

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -140,6 +140,7 @@ function fetch_metadata_doc( string $url ) {
 		'headers' => [
 			'Accept' => sprintf( '%s;q=1.0, application/json;q=0.8', CONTENT_TYPE ),
 		],
+		'timeout' => 7,
 	] );
 	if ( is_wp_error( $response ) ) {
 		return $response;


### PR DESCRIPTION
Locally I've been testing this and frequently I will get a timeout error when fetching the FAIR document meta. Increasing the timeout to 7 seems to provide a more consistent experience.