### PR TITLE
Remove the `main` constraint when running the PHPCS workflow.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.


### PR DESCRIPTION
This ensures that the PHP coding standards workflow will run on all PRs regardless of their base branch.

Fixes #139 