### PR TITLE
Fix check_requirements() in installer

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -342,7 +342,9 @@ function version_requirements( ReleaseDocument $release ) {
 	}
 	foreach ( $release->suggests as $pkg => $vers ) {
 		$vers = preg_replace( '/^[^0-9]+/', '', $vers );
-		$required_versions['tested_to'] = $pkg === 'env:wp' ? $vers : null;
+		if ( $pkg === 'env:wp' ) {
+			$required_versions['tested_to'] = $vers;
+		}
 	}
 
 	return $required_versions;


### PR DESCRIPTION
Fixes the requirement checking in /inc/packages/admin/info.php to actually check the plugin requirements for installation.

Re: #71 