### PR TITLE
add check to update transient for default icons check

### DIFF
--- a/inc/icons/namespace.php
+++ b/inc/icons/namespace.php
@@ -24,10 +24,12 @@ function bootstrap() {
  * @return stdClass
  */
 function set_default_icon( $transient ) {
-	foreach ( $transient->response as $updates ) {
-		$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
-		$url = add_query_arg( 'color', set_random_color(), $url );
-		$updates->icons['default'] = $url;
+	if ( property_exists( $transient, 'response' ) ) {
+		foreach ( $transient->response as $updates ) {
+			$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
+			$url = add_query_arg( 'color', set_random_color(), $url );
+			$updates->icons['default'] = $url;
+		}
 	}
 
 	return $transient;

--- a/inc/icons/namespace.php
+++ b/inc/icons/namespace.php
@@ -24,12 +24,14 @@ function bootstrap() {
  * @return stdClass
  */
 function set_default_icon( $transient ) {
-	if ( property_exists( $transient, 'response' ) ) {
-		foreach ( $transient->response as $updates ) {
-			$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
-			$url = add_query_arg( 'color', set_random_color(), $url );
-			$updates->icons['default'] = $url;
-		}
+	if ( ! property_exists( $transient, 'response' ) ) {
+		return $transient;
+	}
+
+	foreach ( $transient->response as $updates ) {
+		$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
+		$url = add_query_arg( 'color', set_random_color(), $url );
+		$updates->icons['default'] = $url;
 	}
 
 	return $transient;


### PR DESCRIPTION
I came across an error during another plugin update where the `$transient` did not have a `response` property. This fixes it.