### PR TITLE
Add methods for slugs with DID

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,6 +34,7 @@ function bootstrap() {
 	Icons\bootstrap();
 	Importers\bootstrap();
 	Pings\bootstrap();
+	Plugins\bootstrap();
 	Salts\bootstrap();
 	Settings\bootstrap();
 	Updater\bootstrap();

--- a/inc/plugins/namespace.php
+++ b/inc/plugins/namespace.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Sets DID-less plugin slug as active.
+ *
+ * @package FAIR
+ */
+
+namespace FAIR\Plugins;
+
+use function FAIR\Updater\init;
+
+/**
+ * Bootstrap
+ *
+ * @return void
+ */
+function bootstrap() {
+	add_filter( 'option_active_plugins', __NAMESPACE__ . '\\set_as_active' );
+	add_filter( 'wp_admin_notice_markup', __NAMESPACE__ . '\\hide_notice', 10, 3 );
+	if ( is_plugin_active( 'git-updater/git-updater.php' ) ) {
+		wp_admin_notice( 'Git Updater is active' );
+	}
+}
+
+/**
+ * Set FAIR plugins as active using DID-less slug.
+ *
+ * @param  array $active_plugins Array of active plugins.
+ *
+ * @return array
+ */
+function set_as_active( $active_plugins ) {
+	remove_filter( 'option_active_plugins', __NAMESPACE__ . '\\set_as_active' );
+	$packages = init();
+	$plugins = $packages['plugins'] ?? [];
+	foreach ( $plugins as $plugin ) {
+		if ( is_plugin_active( plugin_basename( $plugin ) ) ) {
+			$plugins[] = get_didless_slug( $plugin );
+		}
+	}
+	$active_plugins = array_map( 'plugin_basename', array_merge( $active_plugins, $plugins ) );
+
+	return array_unique( $active_plugins );
+}
+
+/**
+ * Return shortened DID withou `did:plc|web'.
+ *
+ * @param  string $did Full DID.
+ *
+ * @return string|void
+ */
+function get_short_did( $did ) {
+	if ( ! empty( $did ) ) {
+		if ( str_contains( $did, ':' ) ) {
+			$did = (string) explode( ':', $did )[2];
+		}
+		return $did;
+	}
+}
+
+/**
+ * Return slug without DID.
+ *
+ * @param  string $slug Current slug.
+ * @param  string $did  Full DID.
+ *
+ * @return string|void
+ */
+function get_didless_slug( $slug, $did = '' ) {
+	if ( empty( $did ) ) {
+		$did = get_file_data( $slug, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
+		$did = get_short_did( $did );
+	}
+	if ( ! empty( $did ) ) {
+		$slug = str_replace( '-' . get_short_did( $did ), '', $slug );
+	}
+
+	return $slug;
+}
+
+/**
+ * Hide notice reporting DID-less plugin is inactive because it doesn't exist.
+ *
+ * @param  string $markup Markup of notice.
+ * @param  string $message Message of notice.
+ * @param  array $args Args of notice.
+ *
+ * @return string
+ */
+function hide_notice( $markup, $message, $args ) {
+	$active = get_option( 'active_plugins' );
+	if ( $args['id'] === 'message' ) {
+		foreach ( $active as $plugin ) {
+			if ( str_contains( $message, $plugin ) && str_contains( $markup, 'error' ) ) {
+				remove_filter( 'wp_admin_notice_markup', __NAMESPACE__ . '\\hide_notice' );
+				return '';
+			}
+		}
+	}
+
+	return $markup;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/inc/disable-openverse/namespace.php';
 require_once __DIR__ . '/inc/icons/namespace.php';
 require_once __DIR__ . '/inc/importers/namespace.php';
 require_once __DIR__ . '/inc/pings/namespace.php';
+require_once __DIR__ . '/inc/plugins/namespace.php';
 require_once __DIR__ . '/inc/salts/namespace.php';
 require_once __DIR__ . '/inc/settings/namespace.php';
 require_once __DIR__ . '/inc/updater/namespace.php';


### PR DESCRIPTION
This PR will/should make any installed FAIR plugin, that was installed with folder at `slug-did`, as an active plugin when using `is_plugin_active( slug )`.

Yes, I'm making a preference for avoiding name collisions by installing as `slug-did`.

Requires https://github.com/fairpm/fair-plugin/pull/150