### PR TITLE
Get and return method specific ID with parse_did()

### DIFF
--- a/inc/packages/did/class-did.php
+++ b/inc/packages/did/class-did.php
@@ -23,7 +23,7 @@ interface DID {
 	/**
 	 * Get the method specific ID from DID.
 	 */
-	public function get_short_id() : string;
+	public function get_msid() : string;
 
 	/**
 	 * Fetch the DID document.

--- a/inc/packages/did/class-did.php
+++ b/inc/packages/did/class-did.php
@@ -21,6 +21,11 @@ interface DID {
 	public function get_id() : string;
 
 	/**
+	 * Get the method specific ID from DID.
+	 */
+	public function get_short_id() : string;
+
+	/**
 	 * Fetch the DID document.
 	 *
 	 * For most DIDs, this will be a remote request, so higher levels should

--- a/inc/packages/did/class-plc.php
+++ b/inc/packages/did/class-plc.php
@@ -30,17 +30,17 @@ class PLC implements DID {
 	 *
 	 * @var string
 	 */
-	protected string $short_id;
+	protected string $msid;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param string $id DID.
-	 * @param string $short_id Method specific ID.
+	 * @param string $msid Method specific ID.
 	 */
-	public function __construct( string $id, string $short_id ) {
+	public function __construct( string $id, string $msid ) {
 		$this->id = $id;
-		$this->short_id = $short_id;
+		$this->msid = $msid;
 	}
 
 	/**
@@ -62,8 +62,8 @@ class PLC implements DID {
 	/**
 	 * Get the method specific ID from DID.
 	 */
-	public function get_short_id() : string {
-		return $this->short_id;
+	public function get_msid() : string {
+		return $this->msid;
 	}
 
 	/**

--- a/inc/packages/did/class-plc.php
+++ b/inc/packages/did/class-plc.php
@@ -26,12 +26,21 @@ class PLC implements DID {
 	protected string $id;
 
 	/**
+	 * Method specific ID.
+	 *
+	 * @var string
+	 */
+	protected string $short_id;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $id DID.
+	 * @param string $short_id Method specific ID.
 	 */
-	public function __construct( string $id ) {
+	public function __construct( string $id, string $short_id ) {
 		$this->id = $id;
+		$this->short_id = $short_id;
 	}
 
 	/**
@@ -48,6 +57,13 @@ class PLC implements DID {
 	 */
 	public function get_id() : string {
 		return $this->id;
+	}
+
+	/**
+	 * Get the method specific ID from DID.
+	 */
+	public function get_short_id() : string {
+		return $this->short_id;
 	}
 
 	/**

--- a/inc/packages/did/class-web.php
+++ b/inc/packages/did/class-web.php
@@ -25,17 +25,17 @@ class Web implements DID {
 	 *
 	 * @var string
 	 */
-	protected string $short_id;
+	protected string $msid;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param string $id DID.
-	 * @param string $short_id Method specific ID.
+	 * @param string $msid Method specific ID.
 	 */
-	public function __construct( string $id, string $short_id ) {
+	public function __construct( string $id, string $msid ) {
 		$this->id = $id;
-		$this->short_id = $short_id;
+		$this->msid = $msid;
 	}
 
 	/**
@@ -57,8 +57,8 @@ class Web implements DID {
 	/**
 	 * Get the method specific ID from DID.
 	 */
-	public function get_short_id() : string {
-		return $this->short_id;
+	public function get_msid() : string {
+		return $this->msid;
 	}
 
 	/**

--- a/inc/packages/did/class-web.php
+++ b/inc/packages/did/class-web.php
@@ -21,12 +21,21 @@ class Web implements DID {
 	protected string $id;
 
 	/**
+	 * Method specific ID.
+	 *
+	 * @var string
+	 */
+	protected string $short_id;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $id DID.
+	 * @param string $short_id Method specific ID.
 	 */
-	public function __construct( string $id ) {
+	public function __construct( string $id, string $short_id ) {
 		$this->id = $id;
+		$this->short_id = $short_id;
 	}
 
 	/**
@@ -43,6 +52,13 @@ class Web implements DID {
 	 */
 	public function get_id() : string {
 		return $this->id;
+	}
+
+	/**
+	 * Get the method specific ID from DID.
+	 */
+	public function get_short_id() : string {
+		return $this->short_id;
 	}
 
 	/**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -44,10 +44,10 @@ function parse_did( string $id ) {
 
 	switch ( $parts[1] ) {
 		case PLC::TYPE:
-			return new PLC( $id );
+			return new PLC( $id, $parts[2] );
 
 		case Web::TYPE:
-			return new Web( $id );
+			return new Web( $id, $parts[2] );
 
 		default:
 			return new WP_Error( 'fair.packages.validate_id.invalid_type', __( 'Unsupported DID type.', 'fair' ) );


### PR DESCRIPTION
Extends `FAIR\Packages\parse_did()` to also return the method specific ID from the full DID.

If you like something better than `$short_id`, LMK.