### PR TITLE
Rename init function

### DIFF
--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -23,7 +23,7 @@ function bootstrap() {
  *
  * @return stdClass
  */
-function get_packages() {
+function init() {
 	/** @var array */
 	$packages = [];
 
@@ -67,7 +67,7 @@ function get_packages() {
  * @return void
  */
 function run() {
-	$packages = get_packages();
+	$packages = init();
 	$plugins = $packages['plugins'] ?? [];
 	$themes = $packages['themes'] ?? [];
 	$packages = array_merge( $plugins, $themes);


### PR DESCRIPTION
Rename of `get_packages()` to `init()` as it seems to make more sense.