### PR TITLE
Add DID hash function

### DIFF
--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -675,7 +675,7 @@ class Upgrader extends WP_Upgrader {
 			return $source;
 		}
 
-		$new_source = trailingslashit( $remote_source ) . $this->package->slug;
+		$new_source = trailingslashit( $remote_source ) . $this->package->slug . '-' . get_did_hash( $this->package->id );
 
 		if ( trailingslashit( strtolower( $source ) ) !== trailingslashit( strtolower( $new_source ) ) ) {
 			$wp_filesystem->move( $source, $new_source, true );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -55,6 +55,19 @@ function parse_did( string $id ) {
 }
 
 /**
+ * Return hash of DID for appending to slug.
+ *
+ * @param  string $id DID
+ *
+ * @return string
+ */
+function get_did_hash( string $id ) : string {
+	$did = parse_did( $id );
+
+	return substr( hash( 'sha256', $did->get_id() ), 0, 6 );
+}
+
+/**
  * Get DID document.
  *
  * @param string $id DID.


### PR DESCRIPTION
Assuming we've decided on a format of `$hash = substr( hash( 'sha256', $did->get_id() ), 0, 6 );`. This creates a simple function to get that hash.

Fixes #124