### PR TITLE
Pass at updating via DID

### DIFF
--- a/inc/packages/class-metadatadocument.php
+++ b/inc/packages/class-metadatadocument.php
@@ -43,6 +43,13 @@ class MetadataDocument {
 	public $slug;
 
 	/**
+	 * File name.
+	 *
+	 * @var string
+	 */
+	public $file;
+
+	/**
 	 * License.
 	 *
 	 * @var string

--- a/inc/packages/class-metadatadocument.php
+++ b/inc/packages/class-metadatadocument.php
@@ -124,6 +124,7 @@ class MetadataDocument {
 		$optional = [
 			'name',
 			'slug',
+			'file',
 			'description',
 			'keywords',
 			'sections',

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -74,6 +74,21 @@ function get_did_hash( string $id ) {
 }
 
 /**
+ * Get file with DID hash.
+ *
+ * @param string $did DID.
+ * @param string $file File name.
+ *
+ * @return string
+ */
+function get_file_with_did_hash( $did, $file ) {
+	list( $slug, $file ) = explode( '/', $file, 2 );
+	$slug = $slug . '-' . get_did_hash( $did );
+
+	return $slug . '/' . $file;
+}
+
+/**
  * Get DID document.
  *
  * @param string $id DID.

--- a/inc/updater/class-fair-updater.php
+++ b/inc/updater/class-fair-updater.php
@@ -45,11 +45,7 @@ class FAIR_Updater {
 	/** @var string */
 	protected $type;
 
-	/**
-	 * Release document.
-	 *
-	 * @var ReleaseDocument
-	 */
+	/** @var ReleaseDocument */
 	protected $release;
 
 	// phpcs:enable

--- a/inc/updater/class-fair-updater.php
+++ b/inc/updater/class-fair-updater.php
@@ -23,6 +23,7 @@ use function FAIR\Packages\fetch_metadata_doc;
 use function FAIR\Packages\fetch_package_metadata;
 use function FAIR\Packages\get_did_document;
 use function FAIR\Packages\get_did_hash;
+use function FAIR\Packages\get_file_with_did_hash;
 use function FAIR\Packages\pick_release;
 
 /**

--- a/inc/updater/class-fair-updater.php
+++ b/inc/updater/class-fair-updater.php
@@ -1,0 +1,462 @@
+<?php
+/*
+ * @author   Andy Fragen
+ * @license  MIT
+ * @link     https://github.com/afragen/git-updater-lite
+ * @package  git-updater-lite
+ */
+
+namespace FAIR\Updater;
+
+use FAIR\Packages\MetadataDocument;
+use FAIR\Packages\ReleaseDocument;
+use Plugin_Upgrader;
+use stdClass;
+use Theme_Upgrader;
+use TypeError;
+use WP_Error;
+use WP_Upgrader;
+
+use const FAIR\Packages\SERVICE_ID;
+
+use function FAIR\Packages\fetch_metadata_doc;
+use function FAIR\Packages\fetch_package_metadata;
+use function FAIR\Packages\get_did_document;
+use function FAIR\Packages\get_did_hash;
+use function FAIR\Packages\pick_release;
+
+/**
+ * Class FAIR_Updater.
+ */
+class FAIR_Updater {
+
+	// phpcs:disable Generic.Commenting.DocComment.MissingShort
+
+	/** @var string */
+	protected $local_version;
+
+	/** @var string */
+	protected $did;
+
+	/** @var MetadataDocument */
+	protected $metadata;
+
+	/** @var string */
+	protected $type;
+
+	/**
+	 * Release document.
+	 *
+	 * @var ReleaseDocument
+	 */
+	protected $release;
+
+	// phpcs:enable
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $packages Associative array as `'DID' => Path to package`.
+	 */
+	public function __construct( string $did, string $filepath ) {
+		$this->did = $did;
+		$data  = get_file_data( $filepath, array( 'Version'   => 'Version'));
+		$this->local_version = $data['Version'];
+	}
+
+	/**
+	 * Get the required versions, (PHP, WP, Tested to).
+	 *
+	 * @return array
+	 */
+	protected function get_required_versions() {
+		foreach ( $this->release->requires as $pkg => $vers ){
+			$vers = preg_replace( '/^[^0-9]+/', '', $vers );
+		if ( $pkg === 'env:php' ) {
+			$required_versions['requires_php'] = $vers;
+		}
+		if ( $pkg === 'env:wp' ) {
+			$required_versions['requires_wp'] = $vers;
+		}
+		}
+		foreach ( $this->release->suggests as $pkg => $vers ) {
+		$vers = preg_replace( '/^[^0-9]+/', '', $vers );
+		if ( $pkg === 'env:wp' ) {
+			$required_versions['tested_to'] = $vers;
+		}
+
+		return $required_versions;
+	}
+}
+
+	/**
+	 * Get API data.
+	 *
+	 * @global string $pagenow Current page.
+	 * @return void|WP_Error
+	 */
+	public function run() {
+		global $pagenow;
+
+		// Needed for mu-plugin.
+		if ( ! isset( $pagenow ) ) {
+			$php_self = isset( $_SERVER['PHP_SELF'] ) ? sanitize_url( wp_unslash( $_SERVER['PHP_SELF'] ) ) : null;
+			if ( null !== $php_self ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$pagenow = basename( $php_self );
+			}
+		}
+
+		// Only run on the following pages.
+		$pages            = array( 'update-core.php', 'update.php', 'plugins.php', 'themes.php' );
+		$view_details     = array( 'plugin-install.php', 'theme-install.php' );
+		$autoupdate_pages = array( 'admin-ajax.php', 'index.php', 'wp-cron.php' );
+		if ( ! in_array( $pagenow, array_merge( $pages, $view_details, $autoupdate_pages ), true ) ) {
+			return;
+		}
+
+		$this->metadata = fetch_package_metadata( $this->did );
+		if ( is_wp_error( $this->metadata)){
+			return $this->metadata;
+		}
+		$this->release = $this->get_data_from_did( $this->did );
+		$this->type = str_replace('wp-', '', $this->metadata->type);
+
+		$this->load_hooks();
+	}
+
+	protected function get_data_from_did( $id, $version = null ) {
+	$document = get_did_document( $id );
+	if ( is_wp_error( $document ) ) {
+		return $document;
+	}
+
+	// Fetch data from the repository.
+	$service = $document->get_service( SERVICE_ID );
+	if ( empty( $service ) ) {
+		return new WP_Error( 'fair.packages.install_plugin.no_service', __( 'DID is not a valid package to install.', 'fair' ) );
+	}
+	$repo_url = $service->serviceEndpoint;
+
+	// Filter to valid keys for signing.
+	$valid_keys = $document->get_fair_signing_keys();
+	if ( empty( $valid_keys ) ) {
+		return new WP_Error( 'fair.packages.install_plugin.no_signing_keys', __( 'DID does not contain valid signing keys.', 'fair' ) );
+	}
+
+	$metadata = fetch_metadata_doc( $repo_url );
+	if ( is_wp_error( $metadata ) ) {
+		return $metadata;
+	}
+
+	// Select the latest release.
+	$releases = array_values( $metadata->releases );
+	usort( $releases, fn ( $a, $b ) => version_compare( $b->version, $a->version ) );
+	$latest = ! empty( $releases ) ? reset( $releases ) : null;
+
+	$release = pick_release( $metadata->releases, $latest->version );
+	if ( empty( $release ) ) {
+		return new WP_Error( 'fair.packages.install_plugin.no_releases', __( 'No releases found in the repository.', 'fair' ) );
+	}
+
+		return $release;
+	}
+
+	/**
+	 * Load hooks.
+	 *
+	 * @return void
+	 */
+	public function load_hooks() {
+		add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 4 );
+		add_filter( "{$this->type}s_api", array( $this, 'repo_api_details' ), 99, 3 );
+		add_filter( "site_transient_update_{$this->type}s", array( $this, 'update_site_transient' ), 20, 1 );
+		if ( ! is_multisite() ) {
+			add_filter( 'wp_prepare_themes_for_js', array( $this, 'customize_theme_update_html' ) );
+		}
+
+		// Load hook for adding authentication headers for download packages.
+		add_filter(
+			'upgrader_pre_download',
+			function () {
+				add_filter( 'http_request_args', array( $this, 'add_auth_header' ), 20, 2 );
+				return false; // upgrader_pre_download filter default return value.
+			}
+		);
+	}
+
+	/**
+	 * Correctly rename dependency for activation.
+	 *
+	 * @param string      $source        Path of $source.
+	 * @param string      $remote_source Path of $remote_source.
+	 * @param WP_Upgrader $upgrader      An Upgrader object.
+	 * @param array       $hook_extra    Array of hook data.
+	 *
+	 * @throws TypeError If the type of $upgrader is not correct.
+	 *
+	 * @return string|WP_Error
+	 */
+	public function upgrader_source_selection( string $source, string $remote_source, WP_Upgrader $upgrader, $hook_extra = null ) {
+		global $wp_filesystem;
+
+		$new_source = $source;
+
+		// Exit if installing.
+		if ( isset( $hook_extra['action'] ) && 'install' === $hook_extra['action'] ) {
+			return $source;
+		}
+
+		if ( ! $upgrader instanceof Plugin_Upgrader && ! $upgrader instanceof Theme_Upgrader ) {
+			throw new TypeError( __METHOD__ . '(): Argument #3 ($upgrader) must be of type Plugin_Upgrader|Theme_Upgrader, ' . esc_attr( gettype( $upgrader ) ) . ' given.' );
+		}
+
+		// Rename plugins.
+		if ( $upgrader instanceof Plugin_Upgrader ) {
+			if ( isset( $hook_extra['plugin'] ) ) {
+				$slug       = dirname( $hook_extra['plugin'] );
+				$new_source = trailingslashit( $remote_source ) . $slug;
+			}
+		}
+
+		// Rename themes.
+		if ( $upgrader instanceof Theme_Upgrader ) {
+			if ( isset( $hook_extra['theme'] ) ) {
+				$slug       = $hook_extra['theme'];
+				$new_source = trailingslashit( $remote_source ) . $slug;
+			}
+		}
+
+		if ( basename( $source ) === $slug ) {
+			return $source;
+		}
+
+		if ( trailingslashit( strtolower( $source ) ) !== trailingslashit( strtolower($new_source ) ) ) {
+			$wp_filesystem->move( $source, $new_source, true );
+		}
+
+		return trailingslashit( $new_source );
+	}
+
+	/**
+	 * Put changelog in plugins_api, return WP.org data as appropriate
+	 *
+	 * @param bool     $result   Default false.
+	 * @param string   $action   The type of information being requested from the Plugin Installation API.
+	 * @param stdClass $response Repo API arguments.
+	 *
+	 * @return stdClass|bool
+	 */
+	public function repo_api_details( $result, string $action, stdClass $response ) {
+		if ( "{$this->type}_information" !== $action ) {
+			return $result;
+		}
+
+		// Exit if not our repo.
+		if ( $response->slug !== $this->metadata->slug ) {
+			return $result;
+		}
+
+		return (object) $this->get_update_data();
+	}
+
+	/**
+	 * Hook into site_transient_update_{plugins|themes} to update from GitHub.
+	 *
+	 * @param stdClass $transient Plugin|Theme update transient.
+	 *
+	 * @return stdClass
+	 */
+	public function update_site_transient( $transient ) {
+		// needed to fix PHP 7.4 warning.
+		if ( ! is_object( $transient ) ) {
+			$transient = new stdClass();
+		}
+
+		$response = $this->get_update_data();
+
+		if ( version_compare( $this->release->version, $this->local_version, '>' ) ) {
+			$response                    = 'plugin' === $this->type ? (object) $response : $response;
+			$key                         = 'plugin' === $this->type ? $response->file : $response['file'];
+			$transient->response[ $key ] = $response;
+		} else {
+			$response = 'plugin' === $this->type ? (object) $response : $response;
+$key = 'plugin' === $this->type ? $response->file : $response['file'];
+			// Add repo without update to $transient->no_update for 'View details' link.
+			$transient->no_update[ $key ] = $response;
+		}
+
+		return $transient;
+	}
+
+	/**
+	 * Add auth header for download package.
+	 *
+	 * @param array  $args Array of http args.
+	 * @param string $url  Download URL.
+	 *
+	 * TODO: Need to test this.
+	 * @return array
+	 */
+	public function add_auth_header( $args, $url ) {
+		if ( property_exists( $this->metadata, 'auth_header' )
+			&& str_contains( $url, $this->metadata->slug )
+		) {
+			$args = array_merge( $args, $this->metadata->auth_header );
+		}
+		return $args;
+	}
+
+	/**
+	 * Get update data for use with transient and API responses.
+	 *
+	 * @return array
+	 */
+	public function get_update_data() {
+	$required_versions = $this->get_required_versions();
+		$file = 'plugin' === $this->type ? get_file_with_did_hash( $this->metadata->id, $this->metadata->file ) : $this->metadata->slug . '-' . get_did_hash( $this->metadata->id );
+
+		$response = array(
+			'name'             => $this->metadata->name,
+			'author'           => $this->metadata->authors[0]->name,
+			'author_uri'       => $this->metadata->authors[0]->url,
+			'slug'             => $this->metadata->slug,
+			$this->type        => $file,
+			'file'             => $file,
+			'url'              => isset( $this->metadata->url ) ? $this->metadata->url : $this->metadata->slug,
+			'sections'         => (array) $this->metadata->sections,
+			'icons'            => get_icons( $this->release->artifacts->icon),
+			'banners'          => get_banners($this->release->artifacts->banner),
+			'update-supported' => true,
+			'requires'         => $required_versions['requires_wp'],
+			'requires_php'     => $required_versions['requires_php'],
+			'new_version'      => $this->release->version,
+			'version'          => $this->release->version,
+			'remote_version'   => $this->release->version,
+			'package'          => $this->release->artifacts->package[0]->url,
+			'tested'           => $required_versions['tested_to'],
+			'external'         => 'xxx',
+		);
+		if ( 'theme' === $this->type ) {
+			$response['theme_uri'] = $response['url'];
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Call theme messaging for single site installation.
+	 *
+	 * @author Seth Carstens
+	 *
+	 * @param array $prepared_themes Array of prepared themes.
+	 *
+	 * @return array
+	 */
+	public function customize_theme_update_html( $prepared_themes ) {
+		$theme = $this->metadata;
+
+		if ( 'theme' !== $this->type ) {
+			return $prepared_themes;
+		}
+
+		if ( ! empty( $prepared_themes[ $theme->slug ]['hasUpdate'] ) ) {
+			$prepared_themes[ $theme->slug ]['update'] = $this->append_theme_actions_content( $theme );
+		} else {
+			$prepared_themes[ $theme->slug ]['description'] .= $this->append_theme_actions_content( $theme );
+		}
+
+		return $prepared_themes;
+	}
+
+	/**
+	 * Create theme update messaging for single site installation.
+	 *
+	 * @author Seth Carstens
+	 *
+	 * @access protected
+	 * @codeCoverageIgnore
+	 *
+	 * @param stdClass $theme Theme object.
+	 *
+	 * @return string (content buffer)
+	 */
+	protected function append_theme_actions_content( $theme ) {
+		$details_url       = esc_attr(
+			add_query_arg(
+				array(
+					'tab'       => 'theme-information',
+					'theme'     => $theme->slug,
+					'TB_iframe' => 'true',
+					'width'     => 270,
+					'height'    => 400,
+				),
+				self_admin_url( 'theme-install.php' )
+			)
+		);
+		$nonced_update_url = wp_nonce_url(
+			esc_attr(
+				add_query_arg(
+					array(
+						'action' => 'upgrade-theme',
+						'theme'  => rawurlencode( $theme->slug ),
+					),
+					self_admin_url( 'update.php' )
+				)
+			),
+			'upgrade-theme_' . $theme->slug
+		);
+
+		$current = get_site_transient( 'update_themes' );
+
+		/**
+		 * Display theme update links.
+		 */
+		ob_start();
+		if ( isset( $current->response[ $theme->slug ] ) ) {
+			?>
+		<p>
+			<strong>
+				<?php
+				printf(
+					/* translators: %s: theme name */
+					esc_html__( 'There is a new version of %s available.', 'fair' ),
+					esc_attr( $theme->name )
+				);
+					printf(
+						' <a href="%s" class="thickbox open-plugin-details-modal" title="%s">',
+						esc_url( $details_url ),
+						esc_attr( $theme->name )
+					);
+				if ( ! empty( $current->response[ $theme->slug ]['package'] ) ) {
+					printf(
+					/* translators: 1: opening anchor with version number, 2: closing anchor tag, 3: opening anchor with update URL */
+						esc_html__( 'View version %1$s details%2$s or %3$supdate now%2$s.', 'fair' ),
+						$theme->remote_version = isset( $theme->remote_version ) ? esc_attr( $theme->remote_version ) : null,
+						'</a>',
+						sprintf(
+							/* translators: %s: theme name */
+							'<a aria-label="' . esc_attr__( '%s: update now', 'fair' ) . '" id="update-theme" data-slug="' . esc_attr( $theme->slug ) . '" href="' . esc_url( $nonced_update_url ) . '">',
+							esc_attr( $theme->name )
+						)
+					);
+				} else {
+					printf(
+					/* translators: 1: opening anchor with version number, 2: closing anchor tag, 3: opening anchor with update URL */
+						esc_html__( 'View version %1$s details%2$s.', 'fair' ),
+						$theme->remote_version = isset( $theme->remote_version ) ? esc_attr( $theme->remote_version ) : null,
+						'</a>'
+					);
+					echo(
+						'<p><i>' . esc_html__( 'Automatic update is unavailable for this theme.', 'fair' ) . '</i></p>'
+					);
+				}
+				?>
+			</strong>
+		</p>
+			<?php
+		}
+
+		return trim( ob_get_clean(), '1' );
+	}
+}

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -1,8 +1,11 @@
 <?php
+/**
+ * Update FAIR packages.
+ *
+ * @package FAIR
+ */
 
 namespace FAIR\Updater;
-
-use Fragen\Git_Updater;
 
 /**
  * Bootstrap.
@@ -28,30 +31,91 @@ function get_packages() {
 	$plugin_path = trailingslashit( WP_PLUGIN_DIR );
 	$plugins     = get_plugins();
 	foreach ( $plugins as $file => $plugin ) {
-		if ( empty( $plugin['UpdateURI'] ) ) {
-			continue;
-		}
 		$plugin_id = get_file_data( $plugin_path . $file, [ 'PluginID' => 'Plugin ID' ] )['PluginID'];
-
 		if ( ! empty( $plugin_id ) ) {
-			$packages['plugins'][] = $plugin_path . $file;
+			$packages['plugins'][ $plugin_id ] = $plugin_path . $file;
 		}
 	}
 
 	$theme_path = WP_CONTENT_DIR . '/themes/';
 	$themes     = wp_get_themes();
 	foreach ( $themes as $file => $theme ) {
-		if ( empty( $theme->get( 'UpdateURI' ) ) ) {
-			continue;
-		}
 		$theme_id = get_file_data( $theme_path . $file . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];
-
 		if ( ! empty( $theme_id ) ) {
-			$packages['themes'][] = $theme_path . $file . '/style.css';
+			$packages['themes'][ $theme_id ] = $theme_path . $file . '/style.css';
 		}
 	}
 
 	return $packages;
+}
+
+/**
+ * Get icons.
+ *
+ * @param  array $icon Array of icon data.
+ *
+ * @return array
+ */
+function get_icons($icon) {
+	if ( empty($icon)){
+		return;
+	}
+
+	$icons_arr = [];
+	$icons = $icon;
+
+	$regular = array_find( $icons, fn ( $icon ) => $icon->width === 772 && $icon->height === 250 );
+	$high_res = array_find( $icons, fn ( $icon ) => $icon->width === 1544 && $icon->height === 500 );
+
+
+	foreach($icons as $icon){
+		foreach( $icon as $mime => $type ){
+			if ( $mime === 'content-type'){
+			if ( str_contains($type,'svg+xml')){
+				$svg = $icon;
+				break;
+			}
+		}
+		}
+	}
+
+	if ( empty( $regular ) && empty( $high_res ) && empty($svg)) {
+		return;
+	}
+
+	$icons_arr['1x'] = $regular->url ?? '';
+	$icons_arr['2x'] = $high_res->url ?? '';
+	$icons_arr['svg'] = $svg->url ?? '';
+
+	return $icons_arr;
+}
+
+/**
+ * Get banners.
+ *
+ * @param  array $banner Banner data.
+ *
+ * @return array
+ */
+function get_banners( $banner ){
+	if ( empty( $banner ) ) {
+		return;
+	}
+
+	$banners_arr = [];
+	$banners = $banner;
+
+	$regular = array_find( $banners, fn ( $banner ) => $banner->width === 772 && $banner->height === 250 );
+	$high_res = array_find( $banners, fn ( $banner ) => $banner->width === 1544 && $banner->height === 500 );
+
+	if ( empty( $regular ) && empty( $high_res ) ) {
+		return;
+	}
+
+	$banners_arr['low'] = $regular->url;
+	$banners_arr['high'] = $high_res->url;
+
+	return $banners_arr;
 }
 
 /**
@@ -64,7 +128,7 @@ function run() {
 	$plugins = $packages['plugins'] ?? [];
 	$themes = $packages['themes'] ?? [];
 	$packages = array_merge( $plugins, $themes);
-	foreach ( $packages as $package ) {
-		( new Git_Updater\Lite( $package ) )->run();
+	foreach ( $packages as $did => $filepath ) {
+		( new FAIR_Updater( $did, $filepath ) )->run();
 	}
 }

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -5,13 +5,6 @@ namespace FAIR\Updater;
 use Fragen\Git_Updater;
 
 /**
- * Exit if called directly.
- */
-if ( ! defined( 'WPINC' ) ) {
-	die;
-}
-
-/**
  * Bootstrap.
  */
 function bootstrap() {


### PR DESCRIPTION
Needs https://github.com/fairpm/mini-fair-repo/pull/19 for `mini-fair-repo`.

Whole bunch of stuff other than start updating installed FAIR plugins via DID. It actually works, mostly. I haven't been able to test themes until there's one to test with.

<img width="1316" alt="screenshot_678" src="https://github.com/user-attachments/assets/740c56fd-af22-441d-b3e6-4a250bfdc867" />

<img width="779" alt="screenshot_679" src="https://github.com/user-attachments/assets/cc605ee6-d34a-4701-8d2f-ae983c7397c1" />

Yes, missing the button.

<img width="1280" alt="screenshot_680" src="https://github.com/user-attachments/assets/1a3f572c-4db6-4e26-8e7f-fb5715e89f27" />

Yes, it does work.

Sorry, for some reason `composer format` doesn't seem to be working locally for me.