### PR TITLE
Only exclude class-lite.php from PHPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,7 +33,7 @@
 	</rule>
 
 	<!-- Exclude third-party dependencies -->
-	<exclude-pattern>inc/updater/class-lite.php</exclude-pattern>
+	<exclude-pattern>inc/updater/class-lite\.php</exclude-pattern>
 
 	<!-- Exclude language files -->
 	<exclude-pattern>languages/*</exclude-pattern>


### PR DESCRIPTION
Update phpcs.xml.dist to only exclude specific file.