### PR TITLE
Ping IndexNow for newly 404ing URLs.

### DIFF
--- a/inc/pings/namespace.php
+++ b/inc/pings/namespace.php
@@ -109,18 +109,51 @@ function handle_key_file_request() {
  * @param WP_Post $post       Post object.
  */
 function ping_indexnow( $new_status, $old_status, $post ) : void {
-	// Only ping for published posts.
-	if ( 'publish' !== $new_status ) {
+	/*
+	 * Skip if post type isn't viewable.
+	 *
+	 * The post type shouldn't change under normal circumstances,
+	 * so it's safe to assume that both the old and new post are
+	 * not viewable.
+	 */
+	if ( ! is_post_type_viewable( $post->post_type ) ) {
 		return;
 	}
 
-	// Skip revisions and autosaves.
+	/*
+	 * Skip for revisions and autosaves.
+	 *
+	 * The IndexNow ping for revisions will be handled by the
+	 * parent post's transition_post_status hook.
+	 */
 	if ( wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
 		return;
 	}
 
-	// Skip non-public post types.
-	if ( ! is_post_type_viewable( $post->post_type ) ) {
+	/*
+	 * Skip if both old an new statuses are private.
+	 *
+	 * The page will have been a 404 before and after.
+	 *
+	 * For pages that are newly a 404, still ping IndexNow
+	 * to encourage removal of the URL from search engines.
+	 */
+	if (
+		! is_post_status_viewable( $new_status )
+		&& ! is_post_status_viewable( $old_status )
+	) {
+		return;
+	}
+
+	/*
+	 * Prevent double pings for block editor legacy meta boxes.
+	 */
+	if (
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		isset( $_GET['meta-box-loader'] )
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.PHP.StrictComparisons.LooseComparison -- form input.
+		&& '1' == $_GET['meta-box-loader']
+	) {
 		return;
 	}
 

--- a/inc/pings/namespace.php
+++ b/inc/pings/namespace.php
@@ -131,7 +131,7 @@ function ping_indexnow( $new_status, $old_status, $post ) : void {
 	}
 
 	/*
-	 * Skip if both old an new statuses are private.
+	 * Skip if both old and new statuses are private.
 	 *
 	 * The page will have been a 404 before and after.
 	 *


### PR DESCRIPTION
Modifies the conditions under which IndexNow is pinged.

**Why**

1. To ensure that newly 404ing URLs are sent to hosts to encourage them to de-index them. 
   In the event someone has accidentally published a page and then unpublished it, it's likely they wish to have the URL removed from search engines asap.
2. Prevent double pings for posts on sites that use legacy meta boxes (a very popular SEO plugin still uses them so it's not uncommon)

**How**

Replaces the check for `'publish' !== $new_status` with a check whether the old and new post statuses are publicly viewable.

If both are not viewable no ping takes place as the URL will be an existing 404 response.

If one is viewable but the other is not, a ping takes place as the page has either being updated or unpublished.

As sites can have custom public post statuses, I've removed the hard coded `publish` status check as `is_post_status_viewable()` will cover a wider range of statuses, including `publish`.

No ping takes place for non-viewable post types as the it shouldn't change without developer intervention, at which point they are responsible for the SEO impacts of the change.

For item 2: Bypass pinging if `'1' == $_GET['meta-box-loader']`

Fixes #158.