### PR TITLE
Bump the minimum WordPress version to 6.4.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,7 @@
 	<config name="testVersion" value="7.4-" />
 
 	<!-- Set the minimum support WordPress version -->
-	<config name="minimum_supported_wp_version" value="5.4"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Set the text domain -->
 	<config name="text_domain" value="fair"/>

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Version: 0.3.0
  * Author: FAIR Contributors
  * License: GPLv2
- * Requires at least: 5.4
+ * Requires at least: 6.4
  * Requires PHP: 7.4
  * Text Domain: fair
  * Domain Path: /languages


### PR DESCRIPTION
This PR bumps the minimum WordPress version to 6.4.

The codebase has calls to functions that were introduced later than our current minimum, WordPress 5.4. For example, `wp_(get_)admin_notice()` was introduced in WordPress 6.4.

83.2% of WordPress websites checked by dotorg/stats are using WordPress 6.4 or greater. 65.9% are using WordPress 6.8 - the latest major at this time.

Here are some of the most popular plugins and their minimum WordPress version:
- Jetpack: 6.7
- WooCommerce: 6.7
- Yoast SEO: 6.6
- Elementor: 6.5
- BuddyPress: 6.1
- Advanced Custom Fields: 6.0
- bbPress: 6.0
- WPForms: 5.5