### PR TITLE
use transient as wp_cache_* only lasts one page load

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -13,7 +13,7 @@ use WP_Error;
 
 const SERVICE_ID = 'FairPackageManagementRepo';
 const CONTENT_TYPE = 'application/json+fair';
-const CACHE_LIFETIME = 5 * MINUTE_IN_SECONDS;
+const CACHE_LIFETIME = 12 * HOUR_IN_SECONDS;
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -181,8 +181,10 @@ function fetch_metadata_doc( string $url ) {
 			'timeout' => 7,
 		] );
 		$code = wp_remote_retrieve_response_code( $response );
-		if ( is_wp_error( $response ) || $code !== 200 ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
+		} elseif ( $code !== 200 ) {
+			return new WP_Error( 'fair.packages.metadata.failure', wp_remote_retrieve_body( $response ) );
 		}
 		set_site_transient( $cache_key, $response, CACHE_LIFETIME );
 	}

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -13,7 +13,7 @@ use WP_Error;
 
 const SERVICE_ID = 'FairPackageManagementRepo';
 const CONTENT_TYPE = 'application/json+fair';
-const DID_CACHE_LIFETIME = 5 * MINUTE_IN_SECONDS;
+const CACHE_LIFETIME = 5 * MINUTE_IN_SECONDS;
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName
 
@@ -95,7 +95,7 @@ function get_did_document( string $id ) {
 	if ( is_wp_error( $document ) ) {
 		return $document;
 	}
-	set_site_transient( $id, $document, DID_CACHE_LIFETIME );
+	set_site_transient( $id, $document, CACHE_LIFETIME );
 
 	return $document;
 }
@@ -183,7 +183,7 @@ function fetch_metadata_doc( string $url ) {
 		if ( is_wp_error( $response ) || $code !== 200 ) {
 			return $response;
 		}
-		set_site_transient( md5( $url ), $response, DID_CACHE_LIFETIME );
+		set_site_transient( md5( $url ), $response, CACHE_LIFETIME );
 	}
 
 	return MetadataDocument::from_response( $response );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -171,8 +171,7 @@ function install_plugin( string $id, ?string $version = null, $skin ) {
  * @return MetadataDocument|WP_Error
  */
 function fetch_metadata_doc( string $url ) {
-	$cache_key = substr( hash( 'sha256', $url ), 0, 10 );
-	$response = get_site_transient( $cache_key );
+	$response = get_site_transient( md5( $url ) );
 	if ( ! $response ) {
 		$response = wp_remote_get( $url, [
 			'headers' => [
@@ -184,7 +183,7 @@ function fetch_metadata_doc( string $url ) {
 		if ( is_wp_error( $response ) || $code !== 200 ) {
 			return $response;
 		}
-		set_site_transient( $cache_key, $response, DID_CACHE_LIFETIME );
+		set_site_transient( md5( $url ), $response, DID_CACHE_LIFETIME );
 	}
 
 	return MetadataDocument::from_response( $response );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -180,7 +180,8 @@ function fetch_metadata_doc( string $url ) {
 			],
 			'timeout' => 7,
 		] );
-		if ( is_wp_error( $response ) ) {
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( is_wp_error( $response ) || $code !== 200 ) {
 			return $response;
 		}
 		set_site_transient( $cache_key, $response, DID_CACHE_LIFETIME );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -171,7 +171,8 @@ function install_plugin( string $id, ?string $version = null, $skin ) {
  * @return MetadataDocument|WP_Error
  */
 function fetch_metadata_doc( string $url ) {
-	$response = get_site_transient( md5( $url ) );
+	$cache_key = md5( $url );
+	$response = get_site_transient( $cache_key );
 	if ( ! $response ) {
 		$response = wp_remote_get( $url, [
 			'headers' => [
@@ -183,7 +184,7 @@ function fetch_metadata_doc( string $url ) {
 		if ( is_wp_error( $response ) || $code !== 200 ) {
 			return $response;
 		}
-		set_site_transient( md5( $url ), $response, CACHE_LIFETIME );
+		set_site_transient( $cache_key, $response, CACHE_LIFETIME );
 	}
 
 	return MetadataDocument::from_response( $response );


### PR DESCRIPTION
Apparently `wp_cache_*` only last through one page load. I'm pretty sure we want to cache these `wp_remote_get()` calls between multiple page loads.

Currently the transient is set for `DID_CACHE_LIFETIME` which is 5 minutes.