### PR TITLE
Skip contributors, only dot org data

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -316,6 +316,7 @@ function render_fyi( MetadataDocument $doc, ReleaseDocument $release ) : void {
 						esc_url( $url ),
 						esc_html( $author->name )
 					);
+					break;
 				}
 				?>
 			</ul>


### PR DESCRIPTION
This skips dot org contributor data in the modal.