### PR TITLE
Simpify getting of ReleaseDocument during updating

### DIFF
--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -7,6 +7,8 @@
 
 namespace FAIR\Packages;
 
+use function FAIR\Updater\add_package_to_release_cache;
+
 use WP_Error;
 use WP_Upgrader;
 
@@ -241,12 +243,7 @@ class Upgrader extends WP_Upgrader {
 		// Resolve the release artifact to a URL.
 		$artifact = pick_artifact_by_lang( $this->release->artifacts->package );
 
-		/**
-		 * Fires before upgrader_pre_download to use package DID in filters.
-		 *
-		 * @param string $did DID.
-		 */
-		do_action( 'get_fair_package_data', $this->package->id );
+		add_package_to_release_cache( $this->package->id );
 		add_filter( 'upgrader_pre_download', 'FAIR\\Updater\\upgrader_pre_download', 10, 1 );
 
 		// Download the package.

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -132,12 +132,7 @@ class Updater {
 			add_filter( 'wp_prepare_themes_for_js', [ $this, 'customize_theme_update_html' ] );
 		}
 
-		/**
-		 * Fires before upgrader_pre_download to use package DID in filters.
-		 *
-		 * @param string $did DID.
-		 */
-		do_action( 'get_fair_package_data', $this->did );
+		add_package_to_release_cache( $this->did );
 		add_filter( 'upgrader_pre_download', __NAMESPACE__ . '\\upgrader_pre_download', 10, 1 );
 	}
 

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -20,16 +20,15 @@ const RELEASE_PACKAGES_CACHE_KEY = 'fair-release-packages';
  */
 function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\run' );
-	add_action( 'get_fair_package_data', __NAMESPACE__ . '\\get_fair_release_data', 10, 1 );
 }
 
 /**
- * Get FAIR ReleaseDocument data.
+ * Add FAIR ReleaseDocument data to cache.
  *
  * @param string $did DID.
  * @return void
  */
-function get_fair_release_data( string $did ) : void {
+function add_package_to_release_cache( string $did ) : void {
 	if ( empty( $did ) ) {
 		return;
 	}


### PR DESCRIPTION
We only really need the DID to create the ReleaseDocument for the packages. Eliminates much complexity.

Tested and seems to work for plugin.php, core-update.php, and auto-updates.