### PR TITLE
Use installation strings when installing

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -200,8 +200,7 @@ function handle_direct_install() {
 	}
 
 	$skin = new WP_Upgrader_Skin();
-	$res = Packages\install_plugin( $id, $skin, $version );
-	var_dump( $res ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
+	Packages\install_plugin( $id, $skin, $version );
 	exit;
 }
 

--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -442,7 +442,7 @@ class Upgrader extends WP_Upgrader {
 	 */
 	public function install( MetadataDocument $package, ReleaseDocument $release, $clear_cache = true, $overwrite = false ) {
 		$this->init();
-		// $this->install_strings();
+		$this->install_strings();
 
 		$this->package = $package;
 		$this->release = $release;

--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -458,6 +458,36 @@ class Upgrader extends WP_Upgrader {
 				return new WP_Error( 'fair.packages.upgrader.install.invalid_type', 'Invalid package type.' );
 		}
 	}
+
+	/**
+	 * Retrieves the path to the file that contains the plugin info.
+	 *
+	 * This isn't used internally in the class, but is called by the skins.
+	 *
+	 * @since WordPress 2.8.0
+	 *
+	 * @return string|false The full path to the main plugin file, or false.
+	 */
+	public function plugin_info() {
+		if ( ! is_array( $this->result ) ) {
+			return false;
+		}
+		if ( empty( $this->result['destination_name'] ) ) {
+			return false;
+		}
+
+		// Ensure to pass with leading slash.
+		$plugin = get_plugins( '/' . $this->result['destination_name'] );
+		if ( empty( $plugin ) ) {
+			return false;
+		}
+
+		// Assume the requested plugin is the first in the list.
+		$pluginfiles = array_keys( $plugin );
+
+		return $this->result['destination_name'] . '/' . $pluginfiles[0];
+	}
+
 	/**
 	 * Checks that the source package contains a valid plugin.
 	 *

--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -489,6 +489,32 @@ class Upgrader extends WP_Upgrader {
 	}
 
 	/**
+	 * Gets the WP_Theme object for a theme.
+	 *
+	 * @since WordPress 2.8.0
+	 * @since WordPress 3.0.0 The `$theme` argument was added.
+	 *
+	 * @param string $theme The directory name of the theme. This is optional, and if not supplied,
+	 *                      the directory name from the last result will be used.
+	 * @return WP_Theme|false The theme's info object, or false `$theme` is not supplied
+	 *                        and the last result isn't set.
+	 */
+	public function theme_info( $theme = null ) {
+		if ( empty( $theme ) ) {
+			if ( ! empty( $this->result['destination_name'] ) ) {
+				$theme = $this->result['destination_name'];
+			} else {
+				return false;
+			}
+		}
+
+		$theme = wp_get_theme( $theme );
+		$theme->cache_delete();
+
+		return $theme;
+	}
+
+	/**
 	 * Checks that the source package contains a valid plugin.
 	 *
 	 * Hooked to the {@see 'upgrader_source_selection'} filter by Plugin_Upgrader::install().

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -162,7 +162,8 @@ function install_plugin( string $id, WP_Upgrader_Skin $skin, ?string $version = 
 		return new WP_Error( 'fair.packages.install_plugin.no_releases', __( 'No releases found in the repository.', 'fair' ) );
 	}
 
-	$upgrader = new Upgrader( $skin );
+	$skin_class = ucwords( str_replace( 'wp-', '', $metadata->type ) ) . '_Installer_Skin';
+	$upgrader = new Upgrader( new $skin_class() );
 	return $upgrader->install( $metadata, $release );
 }
 


### PR DESCRIPTION
This PR enables the installation strings used to display feedback during the installation process.

Additionally, the default Core `Plugin_Installer_Skin` or `Theme_Installer_Skin` is used when installing a plugin or theme respectively. This requires the porting of the `Plugin_Upgrader::plugin_info()` and `Theme_Upgrader::theme_info()` methods to the `Packages\Upgrader` class, as these are used to output action links after the installation process has completed.