### PR TITLE
Explicitly associate the install note with the ID input field.

### DIFF
--- a/assets/css/packages.css
+++ b/assets/css/packages.css
@@ -33,10 +33,10 @@
 	margin-right: 1em;
 }
 
-.fair-direct-install__note {
+#fair-direct-install__note {
 	font-style: italic;
 	text-align: center;
 }
-.fair-direct-install__note code {
+#fair-direct-install__note code {
 	font-style: normal;
 }

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -100,6 +100,7 @@ function render_tab_direct() {
 				name="plugin_id"
 				pattern="did:(web|plc):.+"
 				placeholder="did:..."
+				aria-describedby="fair-direct-install__note"
 			/>
 			<?php submit_button( _x( 'View Details', 'plugin', 'fair' ), '', '', false ); ?>
 		</form>

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -103,7 +103,7 @@ function render_tab_direct() {
 			/>
 			<?php submit_button( _x( 'View Details', 'plugin', 'fair' ), '', '', false ); ?>
 		</form>
-		<p class="fair-direct-install__note">
+		<p id="fair-direct-install__note">
 			<?= __( 'Plugin IDs should be in the format <code>did:web:...</code> or <code>did:plc:...</code>', 'fair' ); ?>
 		</p>
 	</div>


### PR DESCRIPTION
The install note is important to knowing how to fill out the ID input field.

This PR converts the existing "fair-direct-install__note" HTML class to an ID, and uses the ID in the `aria-describedby` attribute of the ID input field.