### PR TITLE
Change `install_plugin()` to `install_package()`.

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -13,8 +13,6 @@ use FAIR\Packages\MetadataDocument;
 use FAIR\Packages\ReleaseDocument;
 use FAIR\Updater;
 
-use WP_Upgrader_Skin;
-
 const TAB_DIRECT = 'fair_direct';
 const ACTION_INSTALL = 'fair-install-plugin';
 const ACTION_INSTALL_NONCE = 'fair-install-plugin';
@@ -234,8 +232,7 @@ function handle_direct_install() {
 		wp_die( __( 'No version specified for the plugin.', 'fair' ) );
 	}
 
-	$skin = new WP_Upgrader_Skin();
-	Packages\install_package( $id, $skin, $version );
+	Packages\install_package( $id, $version );
 	exit;
 }
 

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -235,7 +235,7 @@ function handle_direct_install() {
 	}
 
 	$skin = new WP_Upgrader_Skin();
-	Packages\install_plugin( $id, $skin, $version );
+	Packages\install_package( $id, $skin, $version );
 	exit;
 }
 

--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -9,6 +9,8 @@ namespace FAIR\Packages;
 
 use function FAIR\Updater\add_package_to_release_cache;
 
+use Plugin_Installer_Skin;
+use Theme_Installer_Skin;
 use WP_Error;
 use WP_Upgrader;
 
@@ -338,6 +340,9 @@ class Upgrader extends WP_Upgrader {
 	 * @return bool|WP_Error True if the installation was successful, false or a WP_Error object otherwise.
 	 */
 	protected function install_plugin( $clear_cache, $overwrite ) {
+		$this->skin = new Plugin_Installer_Skin();
+		$this->init();
+
 		if ( $clear_cache ) {
 			// Clear cache so wp_update_plugins() knows about the new plugin.
 			add_action( 'upgrader_process_complete', 'wp_clean_plugins_cache', 9, 0 );
@@ -392,6 +397,9 @@ class Upgrader extends WP_Upgrader {
 	 * @return bool|WP_Error True if the installation was successful, false or a WP_Error object otherwise.
 	 */
 	public function install_theme( $clear_cache, $overwrite ) {
+		$this->skin = new Theme_Installer_Skin();
+		$this->init();
+
 		if ( $clear_cache ) {
 			// Clear cache so wp_update_themes() knows about the new theme.
 			add_action( 'upgrader_process_complete', 'wp_clean_themes_cache', 9, 0 );
@@ -440,7 +448,6 @@ class Upgrader extends WP_Upgrader {
 	 * @return bool|WP_Error True if the installation was successful, false or a WP_Error otherwise.
 	 */
 	public function install( MetadataDocument $package, ReleaseDocument $release, $clear_cache = true, $overwrite = false ) {
-		$this->init();
 		$this->install_strings();
 
 		$this->package = $package;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -126,14 +126,14 @@ function fetch_package_metadata( string $id ) {
 }
 
 /**
- * Install a plugin from a FAIR DID.
+ * Install a package from a FAIR DID.
  *
  * @param string $id DID of the package to install.
  * @param WP_Upgrader_Skin $skin Plugin Installer Skin.
  * @param string|null $version Version to install. If null, the latest version is installed.
  * @return bool|WP_Error True on success, WP_Error on failure.
  */
-function install_plugin( string $id, WP_Upgrader_Skin $skin, ?string $version = null ) {
+function install_package( string $id, WP_Upgrader_Skin $skin, ?string $version = null ) {
 	$document = get_did_document( $id );
 	if ( is_wp_error( $document ) ) {
 		return $document;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -12,7 +12,6 @@ use FAIR\Packages\DID\Web;
 use FAIR\Updater;
 use WP_Error;
 use WP_Upgrader;
-use WP_Upgrader_Skin;
 
 const SERVICE_ID = 'FairPackageManagementRepo';
 const CONTENT_TYPE = 'application/json+fair';
@@ -129,11 +128,10 @@ function fetch_package_metadata( string $id ) {
  * Install a package from a FAIR DID.
  *
  * @param string $id DID of the package to install.
- * @param WP_Upgrader_Skin $skin Plugin Installer Skin.
  * @param string|null $version Version to install. If null, the latest version is installed.
  * @return bool|WP_Error True on success, WP_Error on failure.
  */
-function install_package( string $id, WP_Upgrader_Skin $skin, ?string $version = null ) {
+function install_package( string $id, ?string $version = null ) {
 	$document = get_did_document( $id );
 	if ( is_wp_error( $document ) ) {
 		return $document;
@@ -156,8 +154,7 @@ function install_package( string $id, WP_Upgrader_Skin $skin, ?string $version =
 		return new WP_Error( 'fair.packages.install.no_releases', __( 'No releases found in the repository.', 'fair' ) );
 	}
 
-	$skin_class = ucwords( str_replace( 'wp-', '', $metadata->type ) ) . '_Installer_Skin';
-	$upgrader = new Upgrader( new $skin_class() );
+	$upgrader = new Upgrader();
 	return $upgrader->install( $metadata, $release );
 }
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -142,7 +142,7 @@ function install_package( string $id, WP_Upgrader_Skin $skin, ?string $version =
 	// Filter to valid keys for signing.
 	$valid_keys = $document->get_fair_signing_keys();
 	if ( empty( $valid_keys ) ) {
-		return new WP_Error( 'fair.packages.install_plugin.no_signing_keys', __( 'DID does not contain valid signing keys.', 'fair' ) );
+		return new WP_Error( 'fair.packages.install.no_signing_keys', __( 'DID does not contain valid signing keys.', 'fair' ) );
 	}
 
 	$metadata = fetch_package_metadata( $id );
@@ -153,7 +153,7 @@ function install_package( string $id, WP_Upgrader_Skin $skin, ?string $version =
 	// Select the appropriate release.
 	$release = pick_release( $metadata->releases, $version );
 	if ( empty( $release ) ) {
-		return new WP_Error( 'fair.packages.install_plugin.no_releases', __( 'No releases found in the repository.', 'fair' ) );
+		return new WP_Error( 'fair.packages.install.no_releases', __( 'No releases found in the repository.', 'fair' ) );
 	}
 
 	$skin_class = ucwords( str_replace( 'wp-', '', $metadata->type ) ) . '_Installer_Skin';
@@ -224,7 +224,7 @@ function get_latest_release_from_did( $id ) {
 
 	$valid_keys = $document->get_fair_signing_keys();
 	if ( empty( $valid_keys ) ) {
-		return new WP_Error( 'fair.packages.install_plugin.no_signing_keys', __( 'DID does not contain valid signing keys.', 'fair' ) );
+		return new WP_Error( 'fair.packages.install.no_signing_keys', __( 'DID does not contain valid signing keys.', 'fair' ) );
 	}
 
 	$metadata = fetch_package_metadata( $id );
@@ -234,7 +234,7 @@ function get_latest_release_from_did( $id ) {
 
 	$release = pick_release( $metadata->releases );
 	if ( empty( $release ) ) {
-		return new WP_Error( 'fair.packages.install_plugin.no_releases', __( 'No releases found in the repository.', 'fair' ) );
+		return new WP_Error( 'fair.packages.install.no_releases', __( 'No releases found in the repository.', 'fair' ) );
 	}
 
 	return $release;


### PR DESCRIPTION
`Packages\install_plugin()` is currently only unique to plugins by its name and the `.install_plugin.` portion of its `WP_Error` codes.

Internally, `Packages\install_plugin()` calls `Upgrader::install()`, which _then_ detects the package type and conditionally calls `Upgrader::install_plugin()` or `Upgrader::install_theme()`. Until that conditional call, everything is type-agnostic.

This PR renames `Packages\install_plugin()` to `Packages\install_package()`, and changes the `.install_plugin.` portion of the `WP_Error` codes to `.install.`

Additionally, the `$skin` parameter to `Packages\install_plugin()` isn't necessary as the skin should be determined by the type of package. Rather than keep this determination at the end of `Packages\install_plugin()`, this PR instead sets the appropriate skin class inside `Upgrader::install_plugin()` or `Upgrader::install_theme()`.