### PR TITLE
Return WP_Error for incorrect DID

### DIFF
--- a/inc/packages/did/class-plc.php
+++ b/inc/packages/did/class-plc.php
@@ -67,6 +67,9 @@ class PLC implements DID {
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
 			return new WP_Error( 'fair.packages.did.json_error', __( 'Unable to parse DID document response.', 'fair' ) );
 		}
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) && property_exists( $data, 'message' ) ) {
+			return new WP_Error( 'fair.packages.did.fetch.error', esc_html( $data->message ) );
+		}
 
 		$document = new Document(
 			$data->id,


### PR DESCRIPTION
If incorrect DID is entered in Direct Install a new WP_Error is returned.

<img width="804" height="691" alt="screenshot_692" src="https://github.com/user-attachments/assets/61d15577-330a-4593-a269-ddf433673aea" />
