### PR TITLE
Fix an inconsistent error code in `parse_did()`.

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -53,7 +53,7 @@ function parse_did( string $id ) {
 			return new Web( $id );
 
 		default:
-			return new WP_Error( 'fair.packages.validate_id.invalid_method', __( 'Unsupported DID method.', 'fair' ) );
+			return new WP_Error( 'fair.packages.validate_did.invalid_method', __( 'Unsupported DID method.', 'fair' ) );
 	}
 }
 


### PR DESCRIPTION
The `WP_Error` codes in `parse_did()` are:
- `fair.packages.validate_did.not_did`
- `fair.packages.validate_did.not_uri`
- `fair.packages.validate_id.invalid_method`

This PR changes the last error code to use `validate_did` instead of `validate_id` for consistency with the other error codes.