### PR TITLE
Ensure the returned `MetadataDocument` ID matches the DID in the request.

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -122,7 +122,17 @@ function fetch_package_metadata( string $id ) {
 	}
 	$repo_url = $service->serviceEndpoint;
 
-	return fetch_metadata_doc( $repo_url );
+	$metadata = fetch_metadata_doc( $repo_url );
+
+	if ( is_wp_error( $metadata ) ) {
+		return $metadata;
+	}
+
+	if ( $metadata->id !== $id ) {
+		return new WP_Error( 'fair.packages.fetch_metadata.mismatch', __( 'Fetched metadata does not match the requested DID.', 'fair' ) );
+	}
+
+	return $metadata;
 }
 
 /**


### PR DESCRIPTION
We already verify that the DID matches when getting the DID document. However, we aren't currently doing so for the metadata document.

Per the [related section of the protocol specification](https://github.com/fairpm/fair-protocol/blob/main/specification.md#id):
> Clients SHOULD verify this ID against the DID used to look up the metadata document. If the ID specified in the Metadata Document does not match the expected ID, clients MUST stop processing the document and MUST NOT treat the document as valid for the expected ID.

Since we're already doing this for the DID document, we should do the same for the metadata document.

This also includes a check to make sure that the returned value isn't already a `WP_Error` object, since the return type of `fetch_metadata_doc()` is `MetadataDocument|WP_Error`.