### PR TITLE
Fix the documented type and default value of `MetadataDocument::$sections`.

### DIFF
--- a/inc/packages/class-metadatadocument.php
+++ b/inc/packages/class-metadatadocument.php
@@ -87,9 +87,9 @@ class MetadataDocument {
 	/**
 	 * Sections.
 	 *
-	 * @var string[]
+	 * @var stdClass
 	 */
-	public $sections = [];
+	public $sections;
 
 	/**
 	 * Releases.


### PR DESCRIPTION
The documented type of `MetadataDocument::$sections` is `string[]` and it's defaulted to an empty array.

However, the value as received is actually an object, per [the related section of the spec](https://github.com/fairpm/fair-protocol/blob/main/specification.md#sections). While this is cast to an array in various other parts of the codebase, the documentation in `MetadataDocument` should match the actual value.

This PR changes the documented type to `stdClass` and removes the default value.