### PR TITLE
Remove unused `use` statement in `FAIR\Updater`.

### DIFF
--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -7,8 +7,6 @@
 
 namespace FAIR\Updater;
 
-use FAIR\Packages;
-
 /**
  * Bootstrap.
  */


### PR DESCRIPTION
An unused `use FAIR\Packages` statement in `inc/updater/namespace.php` is currently throwing a PHPCS warning when running locally. The last use of this was removed in [this commit](https://github.com/fairpm/fair-plugin/commit/9302e6b19fa5a7beb1be2fcb403454341b19162f#diff-5481d373888d35fcb90c3eb9e95379bd7b7ed039fe71cba44096b1c62b65e70e).

This PR removes this statement to clean things up and reduce the output of our tooling.