### PR TITLE
Remove Packages, Updater from feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The FAIR plugin implements federated or local versions of the following features
 * Browser and server health checks
 * Other APIs such as the Credits API, Secret Keys API, and Importers API
 * Twemoji images for emojis
-* Direct installation and updating of FAIR packages using DID
+* Installation and updating of packages direct from their source repository, without talking to any centralized server
 
 The default FAIR provider in this plugin is [AspireCloud from AspirePress](https://aspirepress.org/). The AspirePress team were key in helping the FAIR project get off the ground. As the FAIR project grows and other providers come online you will be able to configure your chosen FAIR provider within the plugin.
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,6 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 * Media features provided by OpenVerse are disabled, pending discussion and work by the FAIR working group
 * Ping services are configured to use IndexNow in place of Pingomatic
 
-
-### Experimental Features
-
-As FAIR works towards our plans for full decentralized package management, some features are marked as experimental. These features must be manually opted-in to during development.
-
-* `FAIR_EXPERIMENTAL_PACKAGES` - Define as `true` to enable any experimental features.
-
-
 ## Data Privacy
 
 * See Also: [Linux Foundation Projects Privacy Policy](https://lfprojects.org/policies/privacy-policy/)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The FAIR plugin implements federated or local versions of the following features
 * Browser and server health checks
 * Other APIs such as the Credits API, Secret Keys API, and Importers API
 * Twemoji images for emojis
+* Direct installation and updating of FAIR packages using DID
 
 The default FAIR provider in this plugin is [AspireCloud from AspirePress](https://aspirepress.org/). The AspirePress team were key in helping the FAIR project get off the ground. As the FAIR project grows and other providers come online you will be able to configure your chosen FAIR provider within the plugin.
 
@@ -49,7 +50,7 @@ In addition to the key FAIR implementations, a few other features in WordPress a
 
 As FAIR works towards our plans for full decentralized package management, some features are marked as experimental. These features must be manually opted-in to during development.
 
-* `FAIR_EXPERIMENTAL_PACKAGES` - Define as `true` to enable decentralized package installation, via direct DID input.
+* `FAIR_EXPERIMENTAL_PACKAGES` - Define as `true` to enable any experimental features.
 
 
 ## Data Privacy

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -42,9 +42,6 @@ function bootstrap() {
 	User_Notification\bootstrap();
 	Version_Check\bootstrap();
 
-	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
-	}
-
 	// Self-update check.
 	( new Git_Updater\Lite( PLUGIN_FILE ) )->run();
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,16 +33,17 @@ function bootstrap() {
 	Disable_Openverse\bootstrap();
 	Icons\bootstrap();
 	Importers\bootstrap();
-	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
-		Packages\bootstrap();
-		Updater\bootstrap();
-	}
+	Packages\bootstrap();
 	Pings\bootstrap();
 	Salts\bootstrap();
 	Settings\bootstrap();
+	Updater\bootstrap();
 	Upgrades\bootstrap();
 	User_Notification\bootstrap();
 	Version_Check\bootstrap();
+
+	if ( defined( 'FAIR_EXPERIMENTAL_PACKAGES' ) && FAIR_EXPERIMENTAL_PACKAGES ) {
+	}
 
 	// Self-update check.
 	( new Git_Updater\Lite( PLUGIN_FILE ) )->run();


### PR DESCRIPTION
This removes Packages and Updater from the feature flag to allow default usage of Install and Update of FAIR packages.

We still need a theme package to test.