### PR TITLE
Add release asset header

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -12,6 +12,7 @@
  * Update URI: https://api.fair.pm
  * GitHub Plugin URI: https://github.com/fairpm/fair-plugin
  * Primary Branch: main
+ * Release Asset: true
  * Network: true
  */
 


### PR DESCRIPTION
Add the `Release Asset: true` header for GU to use release assets. @rmccue has manually added this in the Additions tab, but this will make it consistent for users with the installed plugin.

Not strictly speaking necessary but for consistency.

Signed-off-by: Andy Fragen <andy@thefragens.com>
