### PR TITLE
Use local metadata when attempting to get Mini-FAIR data from same site as package is registered

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -148,11 +148,17 @@ function fetch_metadata_doc( string $url ) {
 	$response = fetch_metadata_from_local( $response, $url );
 
 	if ( ! $response ) {
-		$response = wp_remote_get( $url, [
+		$options = [
 			'headers' => [
 				'Accept' => sprintf( '%s;q=1.0, application/json;q=0.8', CONTENT_TYPE ),
 			],
-		] );
+		];
+
+		// Set low timeout for local package.
+		if ( str_contains( $url, home_url() ) ) {
+			$options['timeout'] = 1;
+		}
+		$response = wp_remote_get( $url, $options );
 		$code = wp_remote_retrieve_response_code( $response );
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
Re: #219 

When using FAIR and Mini-FAIR on same site, there is a timeout issue when attempting to to retrieve the Mini-FAIR REST endpoint. 

What I've done is cached the Mini-FAIR Metadata endpoint ( https://github.com/fairpm/mini-fair-repo/pull/38/commits/e899132ba6997f53d349357b8109c0b7f465e596 ) in https://github.com/fairpm/mini-fair-repo/pull/38 and used this cached data to add the data into `fetch_metadata_doc()`

This PR also contains #218. I would recommend merging #218 first.