### PR TITLE
Remove primary dashboard widget news feed

### DIFF
--- a/inc/dashboard-widgets/namespace.php
+++ b/inc/dashboard-widgets/namespace.php
@@ -27,6 +27,12 @@ function bootstrap() {
 
 	add_action( 'admin_head-index.php', __NAMESPACE__ . '\\set_help_content_fair_planet_urls' );
 
+	// Remove the primary feed and link to avoid showing WordPress.org news.
+	add_filter( 'dashboard_primary_link', '__return_empty_string' );
+	add_filter( 'dashboard_primary_feed', function() {
+		return [ 'url' => null ];
+	} );
+
 	// Configure the WordPress Events and News widget to use FAIR.
 	add_filter( 'dashboard_secondary_link', __NAMESPACE__ . '\\get_fair_planet_url' );
 	add_filter( 'dashboard_secondary_feed', __NAMESPACE__ . '\\get_fair_planet_feed' );


### PR DESCRIPTION
This should remove the primary news feed which will come from dot org. The widget is cached for 12 hours so you may not see the results immediately. Below is what it currently looks like with the cache cleared.

<img width="1318" height="694" alt="screenshot_708" src="https://github.com/user-attachments/assets/09f43cab-91a6-4457-846c-758758b21653" />
