### PR TITLE
Supporting mu-plugins usage > Option 1: Update PLUGIN_DIR definition for mu-plugins context awareness

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -32,29 +32,29 @@ if ( __DIR__ === WPMU_PLUGIN_DIR ) {
 define( __NAMESPACE__ . '\PLUGIN_DIR', $fair_dir );
 
 // Include core.
-require_once __DIR__ . '/inc/namespace.php';
-require_once __DIR__ . '/inc/avatars/namespace.php';
-require_once __DIR__ . '/inc/credits/namespace.php';
-require_once __DIR__ . '/inc/dashboard-widgets/namespace.php';
-require_once __DIR__ . '/inc/default-repo/namespace.php';
-require_once __DIR__ . '/inc/disable-openverse/namespace.php';
-require_once __DIR__ . '/inc/icons/namespace.php';
-require_once __DIR__ . '/inc/importers/namespace.php';
-require_once __DIR__ . '/inc/packages/namespace.php';
-require_once __DIR__ . '/inc/packages/admin/namespace.php';
-require_once __DIR__ . '/inc/packages/admin/info.php';
-require_once __DIR__ . '/inc/pings/namespace.php';
-require_once __DIR__ . '/inc/salts/namespace.php';
-require_once __DIR__ . '/inc/settings/namespace.php';
-require_once __DIR__ . '/inc/upgrades/namespace.php';
-require_once __DIR__ . '/inc/updater/namespace.php';
-require_once __DIR__ . '/inc/user-notification/namespace.php';
-require_once __DIR__ . '/inc/version-check/namespace.php';
+require_once PLUGIN_DIR . '/inc/namespace.php';
+require_once PLUGIN_DIR . '/inc/avatars/namespace.php';
+require_once PLUGIN_DIR . '/inc/credits/namespace.php';
+require_once PLUGIN_DIR . '/inc/dashboard-widgets/namespace.php';
+require_once PLUGIN_DIR . '/inc/default-repo/namespace.php';
+require_once PLUGIN_DIR . '/inc/disable-openverse/namespace.php';
+require_once PLUGIN_DIR . '/inc/icons/namespace.php';
+require_once PLUGIN_DIR . '/inc/importers/namespace.php';
+require_once PLUGIN_DIR . '/inc/packages/namespace.php';
+require_once PLUGIN_DIR . '/inc/packages/admin/namespace.php';
+require_once PLUGIN_DIR . '/inc/packages/admin/info.php';
+require_once PLUGIN_DIR . '/inc/pings/namespace.php';
+require_once PLUGIN_DIR . '/inc/salts/namespace.php';
+require_once PLUGIN_DIR . '/inc/settings/namespace.php';
+require_once PLUGIN_DIR . '/inc/upgrades/namespace.php';
+require_once PLUGIN_DIR . '/inc/updater/namespace.php';
+require_once PLUGIN_DIR . '/inc/user-notification/namespace.php';
+require_once PLUGIN_DIR . '/inc/version-check/namespace.php';
 
 // External dependencies.
-require_once __DIR__ . '/inc/compatibility/php-polyfill.php';
-require_once __DIR__ . '/inc/compatibility/wp-polyfill.php';
-require_once __DIR__ . '/inc/updater/class-lite.php';
+require_once PLUGIN_DIR . '/inc/compatibility/php-polyfill.php';
+require_once PLUGIN_DIR . '/inc/compatibility/wp-polyfill.php';
+require_once PLUGIN_DIR . '/inc/updater/class-lite.php';
 
 /**
  * Load translations.

--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,7 @@ namespace FAIR;
 const VERSION = '0.4.1';
 const PLUGIN_FILE = __FILE__;
 
-// Define PLUGIN_DIR depending on whether this is copied/included as an mu-plugins/fair-plugin.php or similar file
+// Define PLUGIN_DIR depending on whether this is copied/included as an mu-plugins/fair-plugin.php or similar file.
 $fair_dir = __DIR__;
 
 if ( __DIR__ === WPMU_PLUGIN_DIR ) {

--- a/plugin.php
+++ b/plugin.php
@@ -19,9 +19,19 @@
 namespace FAIR;
 
 const VERSION = '0.4.1';
-const PLUGIN_DIR = __DIR__;
 const PLUGIN_FILE = __FILE__;
 
+// Define PLUGIN_DIR depending on whether this is copied/included as an mu-plugins/fair-plugin.php or similar file
+$fair_dir = __DIR__;
+
+if ( __DIR__ === WPMU_PLUGIN_DIR ) {
+	// mu-plugin include detected, reference the fair-plugin subdirectory for the other files.
+	$fair_dir .= '/fair-plugin';
+}
+
+define( __NAMESPACE__ . '\PLUGIN_DIR', $fair_dir );
+
+// Include core.
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/avatars/namespace.php';
 require_once __DIR__ . '/inc/credits/namespace.php';

--- a/plugin.php
+++ b/plugin.php
@@ -19,17 +19,8 @@
 namespace FAIR;
 
 const VERSION = '0.4.1';
+const PLUGIN_DIR = __DIR__ === WPMU_PLUGIN_DIR ? __DIR__ . '/fair-plugin' : __DIR__;
 const PLUGIN_FILE = __FILE__;
-
-// Define PLUGIN_DIR depending on whether this is copied/included as an mu-plugins/fair-plugin.php or similar file.
-$fair_dir = __DIR__;
-
-if ( __DIR__ === WPMU_PLUGIN_DIR ) {
-	// mu-plugin include detected, reference the fair-plugin subdirectory for the other files.
-	$fair_dir .= '/fair-plugin';
-}
-
-define( __NAMESPACE__ . '\PLUGIN_DIR', $fair_dir );
 
 // Include core.
 require_once PLUGIN_DIR . '/inc/namespace.php';


### PR DESCRIPTION
# Supporting mu-plugins usage

* Option 1: [Supporting using plugin.php as the mu-plugin loader](https://github.com/fairpm/fair-plugin/pull/234) (this PR)
* Option 2: [Add an mu-plugin stub file with the same plugin headers](https://github.com/fairpm/fair-plugin/pull/235)

## Summary

I would like hosting platforms to be more easily able to copy the `plugin.php` into the `mu-plugins` directory and have it reference the subdirectory `fair-plugin` more easily.

## Benefits

* FAIR plugin can be loaded as an mu-plugin
* It appears as Must-Use automatically in the plugins area
* The current plugin header information can be utilized in the plugins area which includes version number
* Ease of turning the plugin into an mu-plugin
* No custom [mu-plugins loader](https://github.com/jazzsequence/plague-music-wp-upstream/blob/main/wp-content/mu-plugins/loader.php) or [custom plugin loader (as MU)](https://gist.github.com/afragen/9117fd930d9be16be8a5f450b809dfa8) needed

## Cons

* FAIR plugin code itself is modified to change which directory it uses based on whether in mu-plugins context
* FAIR plugin code hardcodes the fair-plugin slug when used in mu-plugins context

## Examples

### Example in "Must-Use" section

<img width="953" height="247" alt="FAIR plugin in the Must-Use plugins section" src="https://github.com/user-attachments/assets/e68682fc-5040-4292-88ec-d6c002a3869f" />

### Example in "Must-Use" section when just a PHP file including the plugin

<img width="819" height="228" alt="FAIR plugin being included by an mu-plugins loader, shown in the Must-Use plugins section" src="https://github.com/user-attachments/assets/de62f790-ffbc-4072-a498-d73abfea8591" />