### PR TITLE
Supporting mu-plugins usage > Option 2: Add an mu-plugin stub file with the same plugin headers

### DIFF
--- a/inc/stub-mu-plugin.php
+++ b/inc/stub-mu-plugin.php
@@ -16,4 +16,9 @@
  * Network: true
  */
 
+/**
+ * This is a stub file you can use for your mu-plugins implementation of the FAIR plugin.
+ *
+ * Copy this into wp-content/mu-plugins/fair-plugin.php and modify as needed.
+ */
 require_once __DIR__ . '/fair-plugin/plugin.php';


### PR DESCRIPTION
# Supporting mu-plugins usage

* Option 1: [Supporting using plugin.php as the mu-plugin loader](https://github.com/fairpm/fair-plugin/pull/234)
* Option 2: [Add an mu-plugin stub file with the same plugin headers](https://github.com/fairpm/fair-plugin/pull/235) (this PR)

## Summary

This is the flip side of https://github.com/fairpm/fair-plugin/pull/234 which instead of updating the plugin file to support being used as the mu-plugin file itself, this will be a separate stub file that could then be copied/used by hosting environments as the mu-plugin loader and includes plugin header information.

I would like hosting platforms to be more easily able to copy the mu-plugin stub into the `mu-plugins` directory and have it reference the subdirectory `fair-plugin` more easily.

## Benefits

* FAIR plugin can be loaded as an mu-plugin
* It appears as Must-Use automatically in the plugins area
* The current plugin header information can be utilized in the plugins area which includes version number
* Ease of turning the plugin into an mu-plugin
* No custom [mu-plugins loader](https://github.com/jazzsequence/plague-music-wp-upstream/blob/main/wp-content/mu-plugins/loader.php) or [custom plugin loader (as MU)](https://gist.github.com/afragen/9117fd930d9be16be8a5f450b809dfa8) needed

## Cons

* Stub file headers have to stay in sync with `plugin.php`
* Stub file hardcodes the fair-plugin slug

## Examples

### Example in "Must-Use" section

<img width="953" height="247" alt="FAIR plugin in the Must-Use plugins section" src="https://github.com/user-attachments/assets/e68682fc-5040-4292-88ec-d6c002a3869f" />

### Example in "Must-Use" section when just a PHP file including the plugin

<img width="819" height="228" alt="FAIR plugin being included by an mu-plugins loader, shown in the Must-Use plugins section" src="https://github.com/user-attachments/assets/de62f790-ffbc-4072-a498-d73abfea8591" />