### PR TITLE
Icons: Guard against a non-array updates response

### DIFF
--- a/inc/icons/namespace.php
+++ b/inc/icons/namespace.php
@@ -35,7 +35,7 @@ function set_default_icon( $transient ) {
 		return $transient;
 	}
 
-	foreach ( $transient->response as $updates ) {
+	foreach ( (array) $transient->response as $updates ) {
 		$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
 		$url = add_query_arg( 'color', set_random_color(), $url );
 		$updates->icons['default'] = $url;

--- a/inc/icons/namespace.php
+++ b/inc/icons/namespace.php
@@ -31,11 +31,11 @@ function set_default_icon( $transient ) {
 		$transient = new stdClass();
 	}
 
-	if ( ! property_exists( $transient, 'response' ) ) {
+	if ( ! property_exists( $transient, 'response' ) || ! is_array( $transient->response ) ) {
 		return $transient;
 	}
 
-	foreach ( (array) $transient->response as $updates ) {
+	foreach ( $transient->response as $updates ) {
 		$url = plugin_dir_url( PLUGIN_FILE ) . 'inc/icons/svg.php';
 		$url = add_query_arg( 'color', set_random_color(), $url );
 		$updates->icons['default'] = $url;


### PR DESCRIPTION
For some reason I saw a number of the following errors. It seems to happen after the cache is cleared.

`Warning: foreach() argument must be of type array|object, null given in /sites/thefragens.com/files/wp-content/plugins/fair-plugin/inc/icons/namespace.php on line 38`

It seems that sometimes `$transient->response` can be null. I have no idea why but this should fix it.