### PR TITLE
Prevent pings of unpublished URLs.

### DIFF
--- a/inc/pings/namespace.php
+++ b/inc/pings/namespace.php
@@ -102,42 +102,6 @@ function handle_key_file_request() {
 }
 
 /**
- * Determines whether a post status is considered "viewable".
- *
- * Polyfill of `is_post_status_viewable()` for WordPress versions prior to 5.7.0.
- *
- * @param string|stdClass $post_status Post status name or object.
- * @return bool Whether the post status should be considered viewable.
- */
-function is_post_status_viewable_polyfill( $post_status ) : bool {
-	// Defer to WordPress core if available (5.7.0+).
-	if ( function_exists( 'is_post_status_viewable' ) ) {
-		return is_post_status_viewable( $post_status );
-	}
-
-	if ( is_scalar( $post_status ) ) {
-		$post_status = get_post_status_object( $post_status );
-
-		if ( ! $post_status ) {
-			return false;
-		}
-	}
-
-	if (
-		! is_object( $post_status ) ||
-		$post_status->internal ||
-		$post_status->protected
-	) {
-		return false;
-	}
-
-	$is_viewable = $post_status->publicly_queryable || ( $post_status->_builtin && $post_status->public );
-
-	/** This filter is documented in wp-includes/post.php */
-	return true === apply_filters( 'is_post_status_viewable', $is_viewable, $post_status );
-}
-
-/**
  * Ping IndexNow when a post status changes.
  *
  * @param string  $new_status New post status.
@@ -145,12 +109,8 @@ function is_post_status_viewable_polyfill( $post_status ) : bool {
  * @param WP_Post $post       Post object.
  */
 function ping_indexnow( $new_status, $old_status, $post ) : void {
-	/*
-	 * Skip if post isn't viewable.
-	 *
-	 * Use the polyfill version of is_post_status_viewable() for compatibility with WP < 5.7.0.
-	 */
-	if ( ! is_post_type_viewable( $post->post_type ) || ! is_post_status_viewable_polyfill( $new_status ) ) {
+	// Skip if the post isn't viewable.
+	if ( ! is_post_type_viewable( $post->post_type ) || ! is_post_status_viewable( $new_status ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Follow up to #160.

~In my earlier pull request, I _broke compatibility for WordPress versions prior to 5.7.0_ as `is_post_status_viewable()` was unavailable in those versions. I've introduced a polyfill to use in it's place.~

The previous pull request was sending the permalink if the new status was unviewable and the old status was. This was another mistake by yours truely. In this case WP would submit the plain permalink used for previewing links, eg `example.com?p=1`, rather than the original link sent to IndexNow, eg `example.com/hello-world`

~ping @rmccue @afragen: this is probably important given the fatal error I introduced in old WP versions.~