### PR TITLE
Use bridged data from legacy endpoints

### DIFF
--- a/inc/default-repo/namespace.php
+++ b/inc/default-repo/namespace.php
@@ -7,6 +7,8 @@
 
 namespace FAIR\Default_Repo;
 
+use FAIR;
+
 /**
  * Bootstrap.
  */
@@ -63,6 +65,10 @@ function replace_repo_api_urls( $status, $args, $url ) {
 
 	// Alter the URL, then reissue the request (with a lock to prevent loops).
 	$url = str_replace( '//api.wordpress.org/', '//' . get_default_repo_domain() . '/', $url );
+
+	// Indicate this is a FAIR install.
+	$url = add_query_arg( '_fair', FAIR\VERSION, $url );
+
 	$is_replacing = true;
 	$response = wp_remote_request( $url, $args );
 	$is_replacing = false;

--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -280,6 +280,9 @@ function render_fyi( MetadataDocument $doc, ReleaseDocument $release ) : void {
 			<?php if ( ! empty( $doc->slug ) ) : ?>
 				<li><strong><?= __( 'Slug:', 'fair' ); ?></strong> <?= esc_attr( $doc->slug ); ?></li>
 			<?php endif; ?>
+			<?php if ( ! empty( $doc->id ) ) : ?>
+				<li><strong><?= __( 'ID:', 'fair' ); ?></strong> <code><?= esc_attr( $doc->id ); ?></code></li>
+			<?php endif; ?>
 			<?php if ( ! empty( $release->requires ) ) : ?>
 				<li>
 					<strong><?= __( 'Requires:', 'fair' ); ?></strong>
@@ -322,8 +325,36 @@ function render_fyi( MetadataDocument $doc, ReleaseDocument $release ) : void {
 				?>
 			</ul>
 		<?php endif ?>
+		<?php
+		$repo_host = get_repository_hostname( $doc->id );
+		if ( $repo_host ) :
+			?>
+			<p><small>Plugin available via FAIR repository hosted at <?php echo esc_html( $repo_host ); ?></small></p>
+		<?php else: ?>
+			<p><small>Plugin available via FAIR repository</small></p>
+		<?php endif; ?>
 	</div>
 	<?php
+}
+
+/**
+ * Get the hostname for the repository hosting a package.
+ *
+ * @param string $did DID to check.
+ * @return string|null Hostname if available, null if there's an error.
+ */
+function get_repository_hostname( string $did ) : ?string {
+	$did_doc = Packages\get_did_document( $did );
+	if ( is_wp_error( $did_doc ) ) {
+		return null;
+	}
+
+	$repo = $did_doc->get_service( Packages\SERVICE_ID );
+	if ( empty( $repo ) ) {
+		return null;
+	}
+
+	return parse_url( $repo->serviceEndpoint, PHP_URL_HOST );
 }
 
 /**

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -32,6 +32,7 @@ function bootstrap() {
 	add_action( 'install_plugins_' . TAB_DIRECT, __NAMESPACE__ . '\\render_tab_direct' );
 	add_action( 'load-plugin-install.php', __NAMESPACE__ . '\\load_plugin_install' );
 	add_action( 'install_plugins_pre_plugin-information', __NAMESPACE__ . '\\maybe_hijack_plugin_info', 0 );
+	add_filter( 'plugin_install_description', __NAMESPACE__ . '\\maybe_add_data_to_description', 10, 2 );
 	add_action( 'wp_ajax_check_plugin_dependencies', __NAMESPACE__ . '\\set_slug_to_hashed' );
 }
 


### PR DESCRIPTION
* Adds _fair parameter to requests to the repository (except .org if that's being used)
* Uses the FAIR info page instead of default, if there's valid bridged data
* Displays the repository name on the info page and card for bridged packages

<img width="1324" height="742" alt="Screenshot 2025-09-20 at 21 44 02@2x" src="https://github.com/user-attachments/assets/ceea50c8-65c2-40c9-8940-3e1d8c3d1388" />

<img width="1546" height="962" alt="Screenshot 2025-09-20 at 21 44 27@2x" src="https://github.com/user-attachments/assets/ef9a6300-e2dc-41e2-966b-c112a6dbf1e5" />
