### PR TITLE
Add the "Activate" button to `get_action_button()`.

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -416,6 +416,10 @@ function get_action_button( MetadataDocument $doc, ReleaseDocument $release ) {
 		$status = 'installed';
 	}
 
+	$file = Updater\get_packages()[ "{$type}s" ][ $doc->id ];
+	$file = $type === 'plugin' ? plugin_basename( $file ) : basename( dirname( $file ) );
+	$slug = $type === 'plugin' ? dirname( $file ) : $file;
+
 	// Do we actually meet the requirements?
 	$compatible = Packages\check_requirements( $release );
 	switch ( $status ) {
@@ -447,10 +451,6 @@ function get_action_button( MetadataDocument $doc, ReleaseDocument $release ) {
 				);
 			}
 
-			$file = Updater\get_packages()[ "{$type}s" ][ $doc->id ];
-			$file = $type === 'plugin' ? plugin_basename( $file ) : basename( dirname( $file ) );
-			$slug = $type === 'plugin' ? dirname( $file ) : $file;
-
 			return sprintf(
 				'<a id="plugin_install_from_iframe" class="update-now button" data-id="%s" data-%s="%s" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
 				esc_attr( $doc->id ),
@@ -465,6 +465,17 @@ function get_action_button( MetadataDocument $doc, ReleaseDocument $release ) {
 			);
 
 		case 'installed':
+			if ( is_plugin_inactive( $file ) ) {
+				return sprintf(
+					'<a href="%s" class="button activate-now button-primary" aria-label="%s" data-name="%s">%s</a>',
+					esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=' . rawurlencode( $file ) ), 'activate-plugin_' . $file ) ),
+					/* translators: %s: The package's name. */
+					esc_attr( sprintf( __( 'Activate %s now', 'fair' ), $doc->name ) ),
+					esc_attr( $doc->name ),
+					esc_html__( 'Activate', 'fair' )
+				);
+			}
+
 			return sprintf(
 				'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
 				esc_html__( 'Installed', 'fair' )


### PR DESCRIPTION
Previously, the "More Details" modal would simply show "Installed" whether the plugin was active or not.

This PR adds the "Activate" button to `get_action_button()` so that an inactive plugin may be activated from the modal.