### PR TITLE
Only support PLC DIDs for now.

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -86,7 +86,7 @@ function handle_did_during_ajax( $result, $action, $args ) {
 	}
 
 	$did = 'did:' . explode( '-did:', str_replace( '--', ':', $slug ), 2 )[1];
-	if ( ! preg_match( '/^did:(web|plc):.+$/', $did ) ) {
+	if ( ! preg_match( '/^did:plc:.+$/', $did ) ) {
 		return $result;
 	}
 
@@ -152,15 +152,15 @@ function render_tab_direct() {
 				type="text"
 				id="plugin_id"
 				name="plugin_id"
-				pattern="did:(web|plc):.+"
-				placeholder="did:..."
+				pattern="did:plc:.+"
+				placeholder="did:plc:..."
 				required
 				aria-describedby="fair-direct-install__note"
 			/>
 			<?php submit_button( _x( 'View Details', 'plugin', 'fair' ), '', '', false ); ?>
 		</form>
 		<p id="fair-direct-install__note">
-			<?= __( 'Plugin IDs should be in the format <code>did:web:...</code> or <code>did:plc:...</code>', 'fair' ); ?>
+			<?= __( 'Plugin IDs should be in the format <code>did:plc:...</code>', 'fair' ); ?>
 		</p>
 	</div>
 	<script>
@@ -257,7 +257,7 @@ function set_slug_to_hashed() : void {
 
 	$escaped_slug = sanitize_text_field( wp_unslash( $_POST['slug'] ) );
 	$did = 'did:' . explode( '-did:', str_replace( '--', ':', $escaped_slug ), 2 )[1];
-	if ( ! preg_match( '/^did:(web|plc):.+$/', $did ) ) {
+	if ( ! preg_match( '/^did:plc:.+$/', $did ) ) {
 		return;
 	}
 
@@ -302,7 +302,7 @@ function maybe_hijack_plugin_info() {
 
 	// Hijack, if the plugin is a FAIR package.
 	$id = sanitize_text_field( wp_unslash( $_REQUEST['plugin'] ) );
-	if ( ! preg_match( '/^did:(web|plc):.+$/', $id ) ) {
+	if ( ! preg_match( '/^did:plc:.+$/', $id ) ) {
 		if ( str_contains( $id, '-did--' ) ) {
 			// Bridged. Convert back to a DID.
 			$split = explode( '-did--', $id, 2 );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -40,7 +40,7 @@ function bootstrap() {
  * @return DID|WP_Error
  */
 function parse_did( string $id ) {
-	if ( ! str_starts_with( $id, 'did:' ) ) {
+	if ( ! str_starts_with( $id, 'did:plc:' ) ) {
 		return new WP_Error( 'fair.packages.validate_did.not_did', __( 'ID is not a valid DID.', 'fair' ) );
 	}
 


### PR DESCRIPTION
Fixes #255 

This PR ensures that we _only_ detect PLC DIDs for now. It's intended to be reverted once we support web DIDs.