### PR TITLE
Workflows: When detecting POT changes, ignore the creation date.

### DIFF
--- a/.github/workflows/generate-pot-pr.yml
+++ b/.github/workflows/generate-pot-pr.yml
@@ -51,7 +51,7 @@ jobs:
           wp i18n make-pot . "./languages/fair.pot" --headers='{"Report-Msgid-Bugs-To":"https://github.com/${{ github.event.repository.full_name }}/issues"}'
 
       - name: Check if there are changes
-        run: echo "CHANGES_DETECTED=$([[ -z $(git status --porcelain) ]] && echo "0" || echo "1")" >> $GITHUB_ENV
+        run: echo "CHANGES_DETECTED=$([[ -z $(git diff --ignore-matching-lines='^"POT-Creation-Date') ]] && echo "0" || echo "1")" >> $GITHUB_ENV
 
       - name: Commit changes
         if: env.CHANGES_DETECTED == 1


### PR DESCRIPTION
When running the `wp i18n make-pot` command, the creation date is updated in the file. In our workflow to create or update a PR when there are changes, the change detection includes the date change even if it's the only one. This results in unnecessary PR creation or updates.

This PR ignores the creation date line when detecting changes.