### PR TITLE
Add WP-CLI support

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -85,3 +85,12 @@ function register_class_path( string $prefix, string $path ) : void {
 	} );
 	Version_Check\bootstrap();
 }
+
+/**
+ * Check if WP-CLI is running.
+ *
+ * @return bool True if running in WP-CLI, false otherwise.
+ */
+function is_wp_cli(): bool {
+	return defined( 'WP_CLI' ) && WP_CLI;
+}

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -28,7 +28,7 @@ function bootstrap() {
 
 	add_filter( 'install_plugins_tabs', __NAMESPACE__ . '\\add_direct_tab' );
 	add_filter( 'plugins_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
-	add_filter( 'plugins_api', __NAMESPACE__ . '\\search_by_did', 10, 3 );
+	add_filter( 'plugins_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
 	add_filter( 'upgrader_pre_download', 'FAIR\\Packages\\upgrader_pre_download', 10, 1 );
 	add_action( 'install_plugins_' . TAB_DIRECT, __NAMESPACE__ . '\\render_tab_direct' );
 	add_action( 'load-plugin-install.php', __NAMESPACE__ . '\\load_plugin_install' );
@@ -98,57 +98,6 @@ function handle_did_during_ajax( $result, $action, $args ) {
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
 
 	return (object) Packages\get_update_data( $did );
-}
-
-/**
- * Enable searching by DID.
- *
- * @param mixed  $result The result of the plugins_api call.
- * @param string $action The action being performed.
- * @param object $args   The arguments passed to the plugins_api call.
- * @return mixed
- */
-function search_by_did( $result, $action, $args ) {
-	if ( 'query_plugins' !== $action || empty( $args->search ) ) {
-		return $result;
-	}
-
-	// The DID comes from a URL-encoded request parameter, and must be decoded first.
-	$did = sanitize_text_field( urldecode( $args->search ) );
-	if ( ! str_starts_with( $did, 'did:plc:' ) || strlen( $did ) !== 32 ) {
-		return $result;
-	}
-
-	$api_data = Packages\get_update_data( $did );
-	if ( is_wp_error( $api_data ) ) {
-		return $result;
-	}
-
-	$api_data = json_decode( json_encode( $api_data ), true );
-	$api_data['description'] = $api_data['sections']['description'];
-	$api_data['short_description'] = substr( strip_tags( trim( $api_data['description'] ) ), 0, 147 ) . '...';
-	$api_data['last_updated'] ??= 0;
-	$api_data['num_ratings'] ??= 0;
-	$api_data['rating'] ??= 0;
-	$api_data['active_installs'] ??= 0;
-
-	// Avoid a double-hashed slug.
-	$hash_suffix = '-' . Packages\get_did_hash( $did );
-	if ( str_ends_with( $api_data['slug'], $hash_suffix ) ) {
-		$api_data['slug'] = str_replace( $hash_suffix, '', $api_data['slug'] );
-	}
-
-	$result = [
-		'plugins' => [ $api_data ],
-		'info' => [
-			'page' => 1,
-			'pages' => 1,
-			'results' => 1,
-			'total' => 1,
-		],
-	];
-
-	return (object) $result;
 }
 
 /**

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -16,7 +16,6 @@ use FAIR\Updater;
 const TAB_DIRECT = 'fair_direct';
 const ACTION_INSTALL = 'fair-install-plugin';
 const ACTION_INSTALL_NONCE = 'fair-install-plugin';
-const ACTION_INSTALL_DID = 'fair-install-did';
 
 /**
  * Bootstrap.
@@ -29,6 +28,8 @@ function bootstrap() {
 	add_filter( 'install_plugins_tabs', __NAMESPACE__ . '\\add_direct_tab' );
 	add_filter( 'plugins_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
 	add_filter( 'plugins_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
+	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
+	add_action( 'upgrader_post_install', 'FAIR\\Packages\\delete_cached_did_for_install', 10, 3 );
 	add_filter( 'upgrader_pre_download', 'FAIR\\Packages\\upgrader_pre_download', 10, 1 );
 	add_action( 'install_plugins_' . TAB_DIRECT, __NAMESPACE__ . '\\render_tab_direct' );
 	add_action( 'load-plugin-install.php', __NAMESPACE__ . '\\load_plugin_install' );
@@ -93,7 +94,6 @@ function handle_did_during_ajax( $result, $action, $args ) {
 
 	( new Updater\Updater( $did ) )->run();
 
-	set_transient( ACTION_INSTALL_DID, $did );
 	Packages\add_package_to_release_cache( $did );
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -837,4 +837,70 @@ function fetch_and_validate_package_alias( DIDDocument $did ) {
 	return $domain;
 }
 
+/**
+ * Enable searching by DID.
+ *
+ * @param mixed  $result The result of the plugins_api call.
+ * @param string $action The action being performed.
+ * @param stdClass $args The arguments passed to the plugins_api call.
+ * @return mixed The search result for the DID.
+ */
+function search_by_did( $result, $action, $args ) {
+	if ( 'query_plugins' !== $action || empty( $args->search ) ) {
+		return $result;
+	}
+
+	// The DID comes from a URL-encoded request parameter, and must be decoded first.
+	$did = sanitize_text_field( urldecode( $args->search ) );
+	if ( ! str_starts_with( $did, 'did:plc:' ) || strlen( $did ) !== 32 ) {
+		return $result;
+	}
+
+	$api_data = get_api_data( $did );
+	if ( is_wp_error( $api_data ) ) {
+		return $result;
+	}
+
+	$result = [
+		'plugins' => [ $api_data ],
+		'info' => [
+			'page' => 1,
+			'pages' => 1,
+			'results' => 1,
+			'total' => 1,
+		],
+	];
+
+	return (object) $result;
+}
+
+/**
+ * Get API data for a DID.
+ *
+ * @param string $did DID.
+ * @return array|WP_Error The API data array or WP_Error on failure.
+ */
+function get_api_data( $did ) {
+	$api_data = get_update_data( $did );
+	if ( is_wp_error( $api_data ) ) {
+		return $api_data;
+	}
+
+	$api_data = json_decode( json_encode( $api_data ), true );
+	$api_data['description'] = $api_data['sections']['description'];
+	$api_data['short_description'] = substr( strip_tags( trim( $api_data['description'] ) ), 0, 147 ) . '...';
+	$api_data['last_updated'] ??= 0;
+	$api_data['num_ratings'] ??= 0;
+	$api_data['rating'] ??= 0;
+	$api_data['active_installs'] ??= 0;
+
+	// Avoid a double-hashed slug.
+	$hash_suffix = '-' . get_did_hash( $did );
+	if ( str_ends_with( $api_data['slug'], $hash_suffix ) ) {
+		$api_data['slug'] = str_replace( $hash_suffix, '', $api_data['slug'] );
+	}
+
+	return $api_data;
+}
+
 // phpcs:enable

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -634,7 +634,7 @@ function get_update_data( $did ) {
  */
 function upgrader_pre_download( $false ) : bool {
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
-	add_filter( 'upgrader_source_selection', __NAMESPACE__ . '\\rename_source_selection', 10, 3 );
+	add_filter( 'upgrader_source_selection', __NAMESPACE__ . '\\rename_source_selection', 11, 3 );
 	return $false;
 }
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -32,6 +32,7 @@ const SERVICE_ID = 'FairPackageManagementRepo';
  */
 function bootstrap() {
 	Admin\bootstrap();
+	WP_CLI\bootstrap();
 }
 
 /**
@@ -937,6 +938,32 @@ function get_api_data( $did ) {
 	}
 
 	return $api_data;
+}
+
+/**
+ * Get a plugin's information when a DID is supplied.
+ *
+ * @param mixed    $result The result of the plugins_api call.
+ * @param string   $action The action being performed.
+ * @param stdClass $args   The arguments passed to the plugins_api call.
+ * @return stdClass|WP_Error The plugin information object or WP_Error.
+ */
+function get_plugin_information( $result, $action, $args ) {
+	if ( $action !== 'plugin_information' || empty( $args->slug ) ) {
+		return $result;
+	}
+
+	$did = sanitize_text_field( $args->slug );
+	if ( ! str_starts_with( $did, 'did:plc:' ) || strlen( $did ) !== 32 ) {
+		return $result;
+	}
+
+	$api_data = get_api_data( $did );
+	if ( is_wp_error( $api_data ) ) {
+		return $result;
+	}
+
+	return (object) $api_data;
 }
 
 // phpcs:enable

--- a/inc/packages/wp-cli/compat/namespace.php
+++ b/inc/packages/wp-cli/compat/namespace.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Packages WP_CLI bootstrap.
+ *
+ * @package FAIR
+ */
+
+namespace FAIR\Packages\WP_CLI\Compat;
+
+use FAIR\Packages as Packages;
+use function WP_CLI\Utils\get_flag_value as get_flag_value;
+use WP_CLI;
+
+/**
+ * Bootstrap.
+ */
+function bootstrap(): void {
+	WP_CLI::add_hook( 'before_run_command', __NAMESPACE__ . '\\maybe_handle_command' );
+}
+
+/**
+ * Maybe prime the environment for a command, or intercept it.
+ *
+ * - Check for a valid DID and supported commands.
+ * - Run the appropriate priming function.
+ * - If the command's arguments need to change, re-run the command and halt.
+ *
+ * @param array $args       The command line arguments.
+ * @param array $assoc_args The associative command line arguments.
+ * @return void
+ */
+function maybe_handle_command( array $args = [], array $assoc_args = [] ): void {
+	$runner = WP_CLI::get_runner();
+	$command_to_run = $runner->find_command_to_run( $args );
+
+	if (
+		is_string( $command_to_run ) // There was an error. WP_CLI will handle it.
+		|| ! isset( $command_to_run[2][1] ) // There is no subcommand.
+	) {
+		return;
+	}
+
+	list( $command, $subcommand ) = $command_to_run[2];
+	// TODO: Add theme support.
+	if ( $command !== 'plugin' ) {
+		return;
+	}
+
+	$items = (array) array_slice( $args, 2 );
+	$dids = array_filter(
+		$items,
+		function ( $did ) {
+			if ( ! str_starts_with( $did, 'did:' ) ) {
+				return false;
+			}
+
+			$did = Packages\parse_did( $did );
+			if ( is_wp_error( $did ) ) {
+				WP_CLI::error( $did->get_error_message() );
+			}
+			return true;
+		}
+	);
+
+	if ( $dids ) {
+		handle_command( $command, $subcommand, $args, $assoc_args, $items, $dids );
+	}
+}
+
+/**
+ * Handle a command with DIDs.
+ *
+ * This may prime the environment, or re-run the command and halt execution.
+ *
+ * @param string   $command    The main command.
+ * @param string   $subcommand The subcommand.
+ * @param string[] $args       The command line arguments.
+ * @param string[] $assoc_args The associative command line arguments.
+ * @param string[] $items      The command's items, such as slugs or DIDs.
+ * @param string[] $dids       The DIDs to replace.
+ * @return void
+ */
+function handle_command( string $command, string $subcommand, array $args, array $assoc_args, array $items, array $dids ): void {
+	$hashed_items = replace_dids_with_hashed_filenames( $items, $dids );
+	if ( $hashed_items === array_values( $items ) ) {
+		return;
+	}
+
+	force_detection_by_did( $dids );
+
+	switch ( $subcommand ) {
+		case 'activate':
+		case 'deactivate':
+		case 'delete':
+		case 'get':
+		case 'is-active':
+		case 'path':
+		case 'status':
+		case 'toggle':
+		case 'uninstall':
+		case 'update':
+			$args = array_merge( [ $command, $subcommand ], $hashed_items );
+			run_command_and_halt( $args, $assoc_args );
+			break;
+		case 'search':
+			prime_for_search();
+			break;
+		case 'install':
+			prime_for_install( $dids );
+
+			if (
+				get_flag_value( $assoc_args, 'activate' )
+				|| get_flag_value( $assoc_args, 'activate-network' )
+			) {
+				intercept_install( $args, $assoc_args, $items );
+			}
+			break;
+		case 'verify-checksums':
+			WP_CLI::log( __( 'The verify-checksums command is not currently supported for DIDs.', 'fair' ) );
+			WP_CLI::halt( 1 );
+			break;
+		default:
+			// Do nothing.
+			break;
+	}
+}
+
+/**
+ * Force WP to detect plugins by their DIDs.
+ *
+ * This adds a filter to 'all_plugins' that duplicates entries
+ * for the hashed filenames to also be accessible by their DIDs.
+ *
+ * @param string[] $dids The DIDs to force detection for.
+ * @return void
+ */
+function force_detection_by_did( array $dids ): void {
+	add_filter(
+		'all_plugins',
+		function ( $all_plugins ) use ( $dids ) {
+			foreach ( $dids as $did ) {
+				$metadata = Packages\fetch_package_metadata( $did );
+				$filename = Packages\get_hashed_filename( $metadata );
+
+				if ( isset( $all_plugins[ $filename ] ) ) {
+					$all_plugins[ $did ] = $all_plugins[ $filename ];
+				}
+			}
+			return $all_plugins;
+		}
+	);
+}
+
+/**
+ * Prime the environment for the search command.
+ *
+ * @return void
+ */
+function prime_for_search(): void {
+	add_filter( 'plugins_api', '\\FAIR\\Packages\\search_by_did', 10, 3 );
+}
+
+/**
+ * Prime the environment for the install command.
+ *
+ * @param string[] $dids The DIDs to install.
+ * @return void
+ */
+function prime_for_install( array $dids ): void {
+	array_map( 'FAIR\\Packages\\add_package_to_release_cache', $dids );
+	add_filter( 'plugins_api', 'FAIR\\Packages\\get_plugin_information', 10, 3 );
+	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
+	add_filter( 'upgrader_pre_download', 'FAIR\\Packages\\upgrader_pre_download', 10, 1 );
+
+	if ( apply_filters( 'fair.packages.updater.verify_signatures', true ) ) {
+		add_filter( 'upgrader_pre_download', 'FAIR\\Updater\\verify_signature_on_download', 9, 4 );
+	}
+}
+
+/**
+ * Intercept the install command.
+ *
+ * After installation, WP-CLI cannot find the plugin by DID.
+ * Forced detection for other commands does not help here.
+ *
+ * - Run the install command without activation.
+ * - Run the activate command if installation was successful.
+ *
+ * @param string[] $args       The command line arguments.
+ * @param string[] $assoc_args The associative command line arguments.
+ * @param string[] $items      The command's items, such as slugs or DIDs.
+ * @return void Does not return. Halts execution after running the command.
+ */
+function intercept_install( array $args, array $assoc_args, array $items ): void {
+	static $intercepted = false;
+	if ( $intercepted ) {
+		return;
+	}
+	$intercepted = true;
+
+	try {
+		$network_activate = get_flag_value( $assoc_args, 'activate-network' );
+		unset( $assoc_args['activate'], $assoc_args['activate-network'] );
+
+		// The install command needs to run first, without activation.
+		WP_CLI::run_command( $args, $assoc_args );
+
+		if ( $network_activate ) {
+			$assoc_args['network'] = 1;
+		}
+		$activation_args = array_merge( [ 'plugin', 'activate' ], $items );
+		WP_CLI::run_command( $activation_args, $assoc_args );
+		WP_CLI::halt( 0 );
+	} catch ( WP_CLI\ExitException $e ) {
+		WP_CLI::halt( $e->getCode() );
+	}
+}
+
+/**
+ * Run a WP-CLI command and halt execution.
+ *
+ * Includes infinite loop protection.
+ *
+ * @param array $args       The command line arguments.
+ * @param array $assoc_args The associative command line arguments.
+ * @return void Does not return. Halts execution after running the command.
+ */
+function run_command_and_halt( array $args, array $assoc_args = [] ): void {
+	static $already_ran = [];
+
+	if ( ! isset( $already_ran[ $args[1] ] ) ) {
+		$already_ran[ $args[1] ] = true;
+
+		try {
+			WP_CLI::run_command( $args, $assoc_args );
+			WP_CLI::halt( 0 );
+		} catch ( WP_CLI\ExitException $e ) {
+			WP_CLI::halt( $e->getCode() );
+		}
+	}
+}
+
+/**
+ * Replace DIDs in an array of items with their hashed filenames.
+ *
+ * @param string[] $items The command line items.
+ * @param string[] $dids  The DIDs to replace.
+ * @return string[] The modified items.
+ */
+function replace_dids_with_hashed_filenames( array $items, array $dids ): array {
+	return array_map(
+		function ( $item ) use ( $dids ) {
+			if ( in_array( $item, $dids, true ) ) {
+				$metadata = Packages\fetch_package_metadata( $item );
+				if ( is_wp_error( $metadata ) ) {
+					WP_CLI::error( $metadata->get_error_message() );
+				}
+
+				return Packages\get_hashed_filename( $metadata );
+			}
+			return $item;
+		},
+		$items
+	);
+}

--- a/inc/packages/wp-cli/namespace.php
+++ b/inc/packages/wp-cli/namespace.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Packages WP_CLI bootstrap.
+ *
+ * @package FAIR
+ */
+
+namespace FAIR\Packages\WP_CLI;
+
+use function FAIR\is_wp_cli;
+
+/**
+ * Bootstrap.
+ *
+ * @return void
+ */
+function bootstrap(): void {
+	if ( ! is_wp_cli() ) {
+		return;
+	}
+
+	Compat\bootstrap();
+}

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -12,7 +12,6 @@ use Plugin_Upgrader;
 use stdClass;
 use Theme_Upgrader;
 use TypeError;
-use WP_Error;
 use WP_Upgrader;
 
 /**
@@ -141,109 +140,10 @@ class Updater {
 		 * @return bool
 		 */
 		if ( apply_filters( 'fair.packages.updater.verify_signatures', true ) ) {
-			add_filter( 'upgrader_pre_download', [ $this, 'verify_signature_on_download' ], 10, 4 );
+			add_filter( 'upgrader_pre_download', 'FAIR\\Updater\\verify_signature_on_download', 10, 4 );
 		}
 
 		Packages\add_package_to_release_cache( $this->did );
-	}
-
-	/**
-	 * Download a package with signature verification.
-	 *
-	 * @param bool|string|WP_Error $reply      Whether to proceed with the download, the path to the downloaded package, or an existing WP_Error object. Default true.
-	 * @param string               $package    The URI of the package. If this is the full path to an existing local file, it will be returned untouched.
-	 * @param WP_Upgrader          $upgrader   The WP_Upgrader instance.
-	 * @param array                $hook_extra Extra hook data.
-	 * @return true|WP_Error True if the signature is valid, otherwise WP_Error.
-	 */
-	public function verify_signature_on_download( $reply, string $package, WP_Upgrader $upgrader, $hook_extra ) {
-		static $has_run = [];
-
-		if ( false !== $reply || ( ! $upgrader instanceof Plugin_Upgrader && ! $upgrader instanceof Theme_Upgrader ) ) {
-			return $reply;
-		}
-
-		// This method is hooked to 'upgrader_pre_download', which is used in WP_Upgrader::download_package().
-		// Bailing on subsequent runs for the same package URI prevents an infinite loop.
-		$key = sha1( $this->did . '_' . $package );
-		if ( isset( $has_run[ $key ] ) ) {
-			return $reply;
-		}
-		$has_run[ $key ] = true;
-
-		// Local files should be returned untouched.
-		if ( ! preg_match( '!^(http|https|ftp)://!i', $package ) && file_exists( $package ) ) {
-			return $package;
-		}
-
-		$artifact = Packages\pick_artifact_by_lang( $this->release->artifacts->package );
-		if ( ! $artifact || $package !== $artifact->url ) {
-			return $reply;
-		}
-
-		$path = $upgrader->download_package( $package, false, $hook_extra );
-		if ( is_wp_error( $path ) ) {
-			return $path;
-		}
-
-		add_filter( 'wp_trusted_keys', [ $this, 'get_trusted_keys' ], 100 );
-		$decoded_base64url = sodium_base642bin( $artifact->signature, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING );
-		$result = verify_file_signature( $path, base64_encode( $decoded_base64url ) );
-		remove_filter( 'wp_trusted_keys', [ $this, 'get_trusted_keys' ], 100 );
-
-		if ( $result === true ) {
-			return $path;
-		}
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		return new WP_Error(
-			'fair.packages.signature_verification.failed',
-			sprintf(
-				/* translators: %s: The package's URL. */
-				__( 'Signature verification could not be performed for the package: %s', 'fair' ),
-				$package
-			)
-		);
-	}
-
-	/**
-	 * Get trusted keys for signature verification.
-	 *
-	 * @return array
-	 */
-	public function get_trusted_keys(): array {
-		$doc = Packages\get_did_document( $this->did );
-		if ( is_wp_error( $doc ) ) {
-			return [];
-		}
-
-		$keys = $doc->get_fair_signing_keys();
-		if ( empty( $keys ) ) {
-			return [];
-		}
-
-		/*
-		 * FAIR uses Base58BTC-encoded Ed25519 keys.
-		 * Core expects base64-encoded keys.
-		 */
-		$recoded_keys = [];
-		foreach ( $keys as $key ) {
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$str = Base58BTC::decode( $key->publicKeyMultibase );
-
-			// Ed25519 keys only.
-			if ( substr( $str, 0, 2 ) !== "\xed\x01" ) {
-				continue;
-			}
-
-			$key_material = substr( $str, 2 );
-			$recoded_keys[] = base64_encode( $key_material );
-		}
-
-		return $recoded_keys;
 	}
 
 	/**

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -7,6 +7,16 @@
 
 namespace FAIR\Updater;
 
+use const FAIR\Packages\CACHE_DID_FOR_INSTALL;
+use const FAIR\Packages\CACHE_RELEASE_PACKAGES;
+use FAIR\Packages;
+use function FAIR\is_wp_cli;
+use Plugin_Upgrader;
+use Theme_Upgrader;
+use WP_CLI;
+use WP_Error;
+use WP_Upgrader;
+
 /**
  * Bootstrap.
  */
@@ -61,4 +71,118 @@ function run() {
 	foreach ( $packages as $did => $filepath ) {
 		( new Updater( $did, $filepath ) )->run();
 	}
+}
+
+/**
+ * Download a package with signature verification.
+ *
+ * @param bool|string|WP_Error $reply      Whether to proceed with the download, the path to the downloaded package, or an existing WP_Error object. Default true.
+ * @param string               $package    The URI of the package. If this is the full path to an existing local file, it will be returned untouched.
+ * @param WP_Upgrader          $upgrader   The WP_Upgrader instance.
+ * @param array                $hook_extra Extra hook data.
+ * @return true|WP_Error True if the signature is valid, otherwise WP_Error.
+ */
+function verify_signature_on_download( $reply, string $package, WP_Upgrader $upgrader, $hook_extra ) {
+	static $has_run = [];
+
+	if ( false !== $reply || ( ! $upgrader instanceof Plugin_Upgrader && ! $upgrader instanceof Theme_Upgrader ) ) {
+		return $reply;
+	}
+
+	$did = get_transient( CACHE_DID_FOR_INSTALL );
+	if ( ! $did ) {
+		return $reply;
+	}
+
+	// This method is hooked to 'upgrader_pre_download', which is used in WP_Upgrader::download_package().
+	// Bailing on subsequent runs for the same package URI prevents an infinite loop.
+	$key = sha1( $did . '_' . $package );
+	if ( isset( $has_run[ $key ] ) ) {
+		return $reply;
+	}
+	$has_run[ $key ] = true;
+
+	// Local files should be returned untouched.
+	if ( ! preg_match( '!^(http|https|ftp)://!i', $package ) && file_exists( $package ) ) {
+		return $package;
+	}
+
+	$releases = get_transient( CACHE_RELEASE_PACKAGES ) ?? [];
+	if ( empty( $releases ) || ! isset( $releases[ $did ] ) ) {
+		return $reply;
+	}
+
+	$artifact = Packages\pick_artifact_by_lang( $releases[ $did ]->artifacts->package );
+	if ( ! $artifact || $package !== $artifact->url ) {
+		return $reply;
+	}
+
+	$path = $upgrader->download_package( $package, false, $hook_extra );
+	if ( is_wp_error( $path ) ) {
+		return $path;
+	}
+
+	add_filter( 'wp_trusted_keys', __NAMESPACE__ . '\\get_trusted_keys', 100 );
+	$decoded_base64url = sodium_base642bin( $artifact->signature, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING );
+	$result = verify_file_signature( $path, base64_encode( $decoded_base64url ) );
+	remove_filter( 'wp_trusted_keys', __NAMESPACE__ . '\\get_trusted_keys', 100 );
+
+	if ( $result === true ) {
+		return $path;
+	}
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return new WP_Error(
+		'fair.packages.signature_verification.failed',
+		sprintf(
+			/* translators: %s: The package's URL. */
+			__( 'Signature verification could not be performed for the package: %s', 'fair' ),
+			$package
+		)
+	);
+}
+
+/**
+ * Get trusted keys for signature verification.
+ *
+ * @return array
+ */
+function get_trusted_keys(): array {
+	$did = get_transient( CACHE_DID_FOR_INSTALL );
+	if ( ! $did ) {
+		return [];
+	}
+
+	$doc = Packages\get_did_document( $did );
+	if ( is_wp_error( $doc ) ) {
+		return [];
+	}
+
+	$keys = $doc->get_fair_signing_keys();
+	if ( empty( $keys ) ) {
+		return [];
+	}
+
+	/*
+		* FAIR uses Base58BTC-encoded Ed25519 keys.
+		* Core expects base64-encoded keys.
+		*/
+	$recoded_keys = [];
+	foreach ( $keys as $key ) {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$str = Base58BTC::decode( $key->publicKeyMultibase );
+
+		// Ed25519 keys only.
+		if ( substr( $str, 0, 2 ) !== "\xed\x01" ) {
+			continue;
+		}
+
+		$key_material = substr( $str, 2 );
+		$recoded_keys[] = base64_encode( $key_material );
+	}
+
+	return $recoded_keys;
 }

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -128,6 +128,15 @@ function verify_signature_on_download( $reply, string $package, WP_Upgrader $upg
 	remove_filter( 'wp_trusted_keys', __NAMESPACE__ . '\\get_trusted_keys', 100 );
 
 	if ( $result === true ) {
+		if ( is_wp_cli() ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: %s: The DID of the package. */
+					__( 'Verified signature for %s', 'fair' ),
+					$did
+				)
+			);
+		}
 		return $path;
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -33,6 +33,8 @@ require_once __DIR__ . '/inc/importers/namespace.php';
 require_once __DIR__ . '/inc/packages/namespace.php';
 require_once __DIR__ . '/inc/packages/admin/namespace.php';
 require_once __DIR__ . '/inc/packages/admin/info.php';
+require_once __DIR__ . '/inc/packages/wp-cli/namespace.php';
+require_once __DIR__ . '/inc/packages/wp-cli/compat/namespace.php';
 require_once __DIR__ . '/inc/pings/namespace.php';
 require_once __DIR__ . '/inc/salts/namespace.php';
 require_once __DIR__ . '/inc/settings/namespace.php';


### PR DESCRIPTION
This PR adds support for the following `wp plugin <subcommand> <did>` commands.

The following commands are supported:
- `activate`
- `deactivate`
- `delete`
- `get`
- `install`
- `is-active`
- `path`
- `search`
- `status`
- `toggle`
- `uninstall`
- `update`

The following commands are not currently supported:
- `verify-checksums` - This relies on the wordpress.org API, and each file in a package has its own checksum which isn't part of the FAIR protocol.

The PR also includes refactoring some of the plugin to facilitate WP-CLI support:
- How a DID for install is cached: Previously, the DID was cached in the AJAX installation handler. This meant that only one DID could be cached, even during a bulk install (such as via WP-CLI). Now, the DID is cached when its artifact's URL matches the package currently being passed for installation. Additionally, the cached DID is cleared after the package has been installed to prevent contamination.
- Signature verification functions: Previously, signature verification was only applied in the Updater class, whose setup is somewhat tightly coupled to installing in an admin context. Now, signature verification has been moved to general functions so that it can be used in various contexts.
- Search by DID: This has been moved from the `Packages\Admin` namespace to the `Packages` namespace, as this is now used in more than just the admin context.
