### PR TITLE
Banner defaults should be empty string, not null

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -540,8 +540,8 @@ function get_banners( $banners ) : array {
 		return [];
 	}
 
-	$banners_arr['low'] = $regular->url;
-	$banners_arr['high'] = $high_res->url;
+	$banners_arr['low'] = $regular->url ?? '';
+	$banners_arr['high'] = $high_res->url ?? '';
 
 	return $banners_arr;
 }


### PR DESCRIPTION
Banner default need to be empty string not null. Error discovered during testing of WP-CLI.