### PR TITLE
Ensure plugin detail sections are ordered consistently

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -96,6 +96,37 @@ function get_section_title( string $id ) {
 }
 
 /**
+ * Order sections by a predefined order.
+ *
+ * @param array<string, string> $sections Sections to order.
+ *
+ * @return array<string, string> Ordered sections.
+ */
+function order_sections_by_predefined_order( array $sections ) : array {
+	$desired_order = [
+		'description',
+		'installation',
+		'faq',
+		'screenshots',
+		'changelog',
+		'security',
+		'reviews',
+		'other_notes',
+	];
+
+	$desired_order_index = array_flip( $desired_order );
+
+	uksort($sections, function( $a, $b ) use ( $desired_order_index ) {
+		$pos_a = $desired_order_index[ $a ] ?? PHP_INT_MAX;
+		$pos_b = $desired_order_index[ $b ] ?? PHP_INT_MAX;
+
+		return $pos_a <=> $pos_b;
+	});
+
+	return $sections;
+}
+
+/**
  * Render page.
  *
  * @param  MetadataDocument $metadata Metadata for page render.

--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -155,7 +155,7 @@ function render_page( MetadataDocument $metadata, string $tab, string $section )
  * @param  string           $section Page section.
  */
 function render( MetadataDocument $doc, string $tab, string $section ) {
-	$sections = (array) $doc->sections;
+	$sections = order_sections_by_predefined_order( (array) $doc->sections );
 
 	if ( ! isset( $sections[ $section ] ) ) {
 		$section = array_keys( $sections )[0];

--- a/tests/phpunit/tests/Packages/Admin/InfoTest.php
+++ b/tests/phpunit/tests/Packages/Admin/InfoTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use function FAIR\Packages\Admin\Info\order_sections_by_predefined_order;
+
+class InfoTest extends WP_UnitTestCase {
+
+	/**
+	 * Tests that sections are ordered in a predefined order.
+	 *
+	 * @dataProvider data_plugin_detail_sections
+	 *
+	 * @param array $sections Sections provided in arbitrary order, as if returned from MetadataDocument.
+	 * @param array $ordered_sections The sections in order we expect them to be.
+	 */
+	public function test_should_return_sections_in_predefined_order( array $sections, array $ordered_sections ) {
+		$this->assertSame(
+			$ordered_sections,
+			order_sections_by_predefined_order( $sections )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 */
+	public static function data_plugin_detail_sections(): array {
+		return [
+			'expected sections' => [
+				'arbitrary order' => [
+					'faq' => '',
+					'screenshots' => '',
+					'changelog' => '',
+					'description' => '',
+					'security' => '',
+					'reviews' => '',
+					'other_notes' => '',
+					'installation' => '',
+				],
+				'expected order' => [
+					'description' => '',
+					'installation' => '',
+					'faq' => '',
+					'screenshots' => '',
+					'changelog' => '',
+					'security' => '',
+					'reviews' => '',
+					'other_notes' => '',
+				],
+			],
+			'unknown sections' => [
+				'arbitrary order' => [
+					'foo' => '',
+					'bar' => '',
+					'baz' => '',
+				],
+				'expected order' => [
+					'foo' => '',
+					'bar' => '',
+					'baz' => '',
+				],
+			],
+			'expected and unknown sections' => [
+				'arbitrary order' => [
+					'faq' => '',
+					'foo' => '',
+					'screenshots' => '',
+					'changelog' => '',
+					'bar' => '',
+					'reviews' => '',
+					'installation' => '',
+					'security' => '',
+				],
+				'expected order' => [
+					'installation' => '',
+					'faq' => '',
+					'screenshots' => '',
+					'changelog' => '',
+					'security' => '',
+					'reviews' => '',
+					'foo' => '',
+					'bar' => '',
+				],
+			],
+			'empty sections' => [
+				'arbitrary order' => [],
+				'expected order' => [],
+			],
+		];
+	}
+}


### PR DESCRIPTION
Order the sections in the plugin details modal based on the WP.org order. Resolves #279.