### PR TITLE
Admin: Fix theme support.

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -42,6 +42,7 @@ function bootstrap() {
 	// Themes.
 	add_filter( 'themes_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
 	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
+	add_filter( 'themes_api_result', __NAMESPACE__ . '\\alter_slugs', 10, 3 );
 
 	// Common.
 	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
@@ -408,30 +409,58 @@ function maybe_hijack_legacy_plugin_info() {
 }
 
 /**
- * Filters the Plugin Installation API response results.
+ * Filters the Installation API response results.
  *
  * @param object|WP_Error $res    Response object or WP_Error.
- * @param string          $action The type of information being requested from the Plugin Installation API.
- * @param object          $args   Plugin API arguments.
- * @return object|WP_Error
+ * @param string          $action The type of information being requested from the Installation API.
+ * @param object          $args   API arguments.
  */
 function handle_did_in_search_results( $res, $action, $args ) {
-	if ( 'query_plugins' !== $action ) {
+	if ( 'query_plugins' !== $action && 'query_themes' !== $action ) {
 		return $res;
 	}
 
-	if ( empty( $res->plugins ) ) {
+	$type = explode( '_', $action )[1];
+
+	if (
+		( $type === 'plugin' && empty( $res->plugins ) )
+		|| ( $type === 'theme' && empty( $res->themes ) )
+	) {
 		return $res;
 	}
 
+<<<<<<< HEAD
 	// Alter the slugs to our globally unique version and populate release cache.
-	foreach ( $res->plugins as &$plugin ) {
-		if ( ! is_fair_plugin( $plugin ) ) {
+	$items = $type === 'plugin' ? $res->plugins : $res->themes;
+
+	// Alter the slugs to our globally unique version.
+	foreach ( $items as &$item ) {
+		if ( ! is_fair_package( $item ) ) {
 			continue;
 		}
 
-		$did = $plugin['_fair']['id'];
-		$plugin['slug'] = esc_attr( $plugin['slug'] . '-' . str_replace( ':', '--', $did ) );
+		if ( $type === 'plugin' ) {
+			$did = $item['_fair']['id'];
+			$item['slug'] = esc_attr( $item['slug'] . '-' . str_replace( ':', '--', $did ) );
+		} else {
+			// Installed themes need to have the slug-didhash format
+			// so their activation status can be determined.
+			$did_hash = Packages\get_did_hash( $item->_fair['id'] );
+			$slug = $item->slug;
+			if ( ! str_ends_with( $slug, '-' . $did_hash ) ) {
+				$slug = $item->slug . '-' . $did_hash;
+			}
+			$theme = wp_get_theme( $slug );
+			if ( $theme->exists() ) {
+				$item->slug = esc_attr( $slug );
+				continue;
+			}
+
+			// Themes that aren't installed need the slug--escaped-did format
+			// so their metadata can be retrieved.
+			$did = $item->_fair['id'];
+			$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
+		}
 		Packages\add_package_to_release_cache( $did );
 	}
 

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -358,7 +358,8 @@ function set_stylesheet_to_hashed_on_theme_activation() {
  * The theme parameter needs to be in the slug-didhash format
  * so that the theme can be found.
  *
- * @return void
+ * @param string $url The URL to filter.
+ * @return string
  */
 function set_theme_to_hashed_for_customize( $url ) {
 	if ( str_contains( $url, 'customize.php?theme=' ) ) {

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -299,7 +299,7 @@ function set_slug_to_hashed() : void {
 }
 
 /**
- * Check if this is a FAIR plugin, for legacy data.
+ * Check if this is a FAIR package, for legacy data.
  *
  * FAIR data is bridged into legacy data via the _fair property, and needs
  * to have a valid DID. We can use this to enhance our existing metadata.
@@ -307,7 +307,7 @@ function set_slug_to_hashed() : void {
  * @param array|stdClass $api_data Legacy dotorg-formatted data to check.
  * @return bool
  */
-function is_fair_plugin( $api_data ) : bool {
+function is_fair_package( $api_data ) : bool {
 	$api = (array) $api_data;
 	if ( empty( $api['_fair'] ) ) {
 		return false;
@@ -382,7 +382,7 @@ function maybe_hijack_legacy_plugin_info() {
 	}
 
 	// Is this a FAIR plugin, actually?
-	if ( ! is_fair_plugin( $api ) ) {
+	if ( ! is_fair_package( $api ) ) {
 		return;
 	}
 
@@ -472,7 +472,7 @@ function sort_sections_in_api( $res ) {
  * @return array Altered actions.
  */
 function maybe_hijack_plugin_install_button( $links, $plugin ) {
-	if ( ! is_fair_plugin( $plugin ) || ! str_contains( $plugin['slug'], '-did--' ) ) {
+	if ( ! is_fair_package( $plugin ) || ! str_contains( $plugin['slug'], '-did--' ) ) {
 		return $links;
 	}
 
@@ -513,7 +513,7 @@ function maybe_hijack_plugin_install_button( $links, $plugin ) {
  * @return string Plugin card description.
  */
 function maybe_add_data_to_description( $description, $plugin ) {
-	if ( ! is_fair_plugin( $plugin ) ) {
+	if ( ! is_fair_package( $plugin ) ) {
 		return $description;
 	}
 

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -44,6 +44,7 @@ function bootstrap() {
 	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
 	add_filter( 'themes_api_result', __NAMESPACE__ . '\\alter_slugs', 10, 3 );
 	add_action( 'load-themes.php', __NAMESPACE__ . '\\set_stylesheet_to_hashed_on_theme_activation' );
+	add_filter( 'wp_prepare_themes_for_js', __NAMESPACE__ . '\\maybe_add_data_to_theme_description', 10, 1 );
 
 	// Common.
 	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
@@ -603,4 +604,34 @@ function maybe_add_data_to_description( $description, $plugin ) {
 	/* translators: %1$s: repository hostname */
 	$description .= '</p><p class="authors"><em>' . sprintf( __( 'Hosted on %1$s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
 	return $description;
+}
+
+/**
+ * Filters the theme description when preparing themes for JS.
+ *
+ * @param array $themes Array of themes prepared for JS.
+ * @return array Array of themes with possible modifications.
+ */
+function maybe_add_data_to_theme_description( $themes ) {
+	foreach ( $themes as &$theme ) {
+		$did = get_file_data( get_stylesheet_directory() . '/style.css', [ 'ThemeID' => 'Theme ID' ] )['ThemeID'];
+		if ( empty( $did ) || ! str_starts_with( $did, 'did:plc:' ) ) {
+			continue;
+		}
+
+		$repo_host = Info\get_repository_hostname( $did );
+		if ( empty( $repo_host ) ) {
+			continue;
+		}
+
+		/* translators: %1$s: repository hostname */
+		$additional_description = '<p class="authors"><em>' . sprintf( __( 'Hosted on %1$s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
+		if ( empty( $theme->description ) ) {
+			$theme['description'] .= '</p>' . $additional_description;
+		} else {
+			$theme['description'] .= $additional_description . '</p>';
+		}
+	}
+	unset( $theme );
+	return $themes;
 }

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -44,6 +44,7 @@ function bootstrap() {
 	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
 	add_filter( 'themes_api_result', __NAMESPACE__ . '\\alter_slugs', 10, 3 );
 	add_action( 'load-themes.php', __NAMESPACE__ . '\\set_stylesheet_to_hashed_on_theme_activation' );
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\set_theme_to_hashed_for_customize', 9 );
 	add_filter( 'wp_prepare_themes_for_js', __NAMESPACE__ . '\\maybe_add_data_to_theme_description', 10, 1 );
 
 	// Common.
@@ -346,6 +347,44 @@ function set_stylesheet_to_hashed_on_theme_activation() {
 	$new_nonce = wp_create_nonce( 'switch-theme_' . $hashed_stylesheet );
 	$_GET['_wpnonce'] = $new_nonce;
 	$_REQUEST['_wpnonce'] = $new_nonce;
+}
+
+/**
+ * Set the theme to the hashed version in the customizer.
+ *
+ * Immediately after installation, the "Live Preview" button
+ * includes the escaped DID, not the hash of the DID.
+ *
+ * The theme parameter needs to be in the slug-didhash format
+ * so that the theme can be found.
+ *
+ * @return void
+ */
+function set_theme_to_hashed_for_customize() {
+	// phpcs:ignore HM.PHP.Isset.MultipleArguments
+	if ( ! isset( $_GET['theme'] ) || ! isset( $_GET['return'] ) ) {
+		return;
+	}
+
+	$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
+	if ( ! str_contains( $request_uri, 'customize.php' ) ) {
+		return;
+	}
+
+
+	$theme = sanitize_text_field( wp_unslash( $_GET['theme'] ) );
+	if ( ! str_contains( $theme, '-did--' ) ) {
+		return;
+	}
+
+	$did = 'did:' . explode( '-did:', str_replace( '--', ':', $theme ), 2 )[1];
+	if ( ! preg_match( '/^did:plc:.+$/', $did ) ) {
+		return;
+	}
+
+	$hashed_theme = explode( '-did--', $theme, 2 )[0] . '-' . Packages\get_did_hash( $did );
+	$_GET['theme'] = $hashed_theme;
+	$_REQUEST['theme'] = $hashed_theme;
 }
 
 /**

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -514,6 +514,7 @@ function handle_did_in_search_results( $res, $action, $args ) {
 		if ( ! str_ends_with( $slug, '-' . $did_hash ) ) {
 			$slug = $item->slug . '-' . $did_hash;
 		}
+		$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 
 		// Installed themes need the slug-didhash format
 		// so their activation status can be determined.
@@ -521,12 +522,9 @@ function handle_did_in_search_results( $res, $action, $args ) {
 			$theme = wp_get_theme( $slug );
 			if ( $theme->exists() ) {
 				$item->slug = esc_attr( $slug );
-				continue;
 			}
 		}
 		Packages\add_package_to_release_cache( $did );
-
-		$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 	}
 
 	return $res;

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -25,12 +25,10 @@ function bootstrap() {
 		return;
 	}
 
+	// Plugins.
 	add_filter( 'install_plugins_tabs', __NAMESPACE__ . '\\add_direct_tab' );
 	add_filter( 'plugins_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
 	add_filter( 'plugins_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
-	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
-	add_action( 'upgrader_post_install', 'FAIR\\Packages\\delete_cached_did_for_install', 10, 3 );
-	add_filter( 'upgrader_pre_download', 'FAIR\\Packages\\upgrader_pre_download', 10, 1 );
 	add_action( 'install_plugins_' . TAB_DIRECT, __NAMESPACE__ . '\\render_tab_direct' );
 	add_action( 'load-plugin-install.php', __NAMESPACE__ . '\\load_plugin_install' );
 	add_action( 'install_plugins_pre_plugin-information', __NAMESPACE__ . '\\maybe_hijack_plugin_info', 0 );
@@ -40,6 +38,15 @@ function bootstrap() {
 	add_filter( 'plugin_install_description', __NAMESPACE__ . '\\maybe_add_data_to_description', 10, 2 );
 	add_action( 'wp_ajax_check_plugin_dependencies', __NAMESPACE__ . '\\set_slug_to_hashed' );
 	add_filter( 'wp_list_table_class_name', __NAMESPACE__ . '\\maybe_override_list_table' );
+
+	// Themes.
+	add_filter( 'themes_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
+	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
+
+	// Common.
+	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
+	add_action( 'upgrader_post_install', 'FAIR\\Packages\\delete_cached_did_for_install', 10, 3 );
+	add_filter( 'upgrader_pre_download', 'FAIR\\Packages\\upgrader_pre_download', 10, 1 );
 
 	// Needed for pre WordPress 6.9 compatibility.
 	if ( ! is_wp_version_compatible( '6.9' ) ) {

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -663,5 +663,6 @@ function maybe_add_data_to_theme_description( $themes ) {
 		}
 	}
 	unset( $theme );
+
 	return $themes;
 }

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -510,18 +510,18 @@ function handle_did_in_search_results( $res, $action, $args ) {
 
 		$did = $item->_fair['id'];
 		$did_hash = Packages\get_did_hash( $item->_fair['id'] );
-		$slug = $item->slug;
-		if ( ! str_ends_with( $slug, '-' . $did_hash ) ) {
-			$slug = $item->slug . '-' . $did_hash;
+		$slug_did_hash = $item->slug;
+		if ( ! str_ends_with( $slug_did_hash, '-' . $did_hash ) ) {
+			$slug_did_hash .= '-' . $did_hash;
 		}
 		$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 
 		// Installed themes need the slug-didhash format
 		// so their activation status can be determined.
 		if ( 'theme' === $type ) {
-			$theme = wp_get_theme( $slug );
+			$theme = wp_get_theme( $slug_did_hash );
 			if ( $theme->exists() ) {
-				$item->slug = esc_attr( $slug );
+				$item->slug = esc_attr( $slug_did_hash );
 			}
 		}
 		Packages\add_package_to_release_cache( $did );

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -44,7 +44,7 @@ function bootstrap() {
 	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
 	add_filter( 'themes_api_result', __NAMESPACE__ . '\\alter_slugs', 10, 3 );
 	add_action( 'load-themes.php', __NAMESPACE__ . '\\set_stylesheet_to_hashed_on_theme_activation' );
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\\set_theme_to_hashed_for_customize', 9 );
+	add_filter( 'clean_url', __NAMESPACE__ . '\\set_theme_to_hashed_for_customize', 10, 3 );
 	add_filter( 'wp_prepare_themes_for_js', __NAMESPACE__ . '\\maybe_add_data_to_theme_description', 10, 1 );
 
 	// Common.
@@ -360,31 +360,21 @@ function set_stylesheet_to_hashed_on_theme_activation() {
  *
  * @return void
  */
-function set_theme_to_hashed_for_customize() {
-	// phpcs:ignore HM.PHP.Isset.MultipleArguments
-	if ( ! isset( $_GET['theme'] ) || ! isset( $_GET['return'] ) ) {
-		return;
+function set_theme_to_hashed_for_customize( $url ) {
+	if ( str_contains( $url, 'customize.php?theme=' ) ) {
+		$theme = explode( 'theme=', $url )[1];
+
+		if ( str_contains( $theme, '-did--' ) ) {
+			$did = 'did:' . explode( '-did:', str_replace( '--', ':', $theme ), 2 )[1];
+
+			if ( preg_match( '/^did:plc:.+$/', $did ) ) {
+				$hashed_theme = explode( '-did--', $theme, 2 )[0] . '-' . Packages\get_did_hash( $did );
+				$url = str_replace( $theme, $hashed_theme, $url );
+			}
+		}
 	}
 
-	$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
-	if ( ! str_contains( $request_uri, 'customize.php' ) ) {
-		return;
-	}
-
-
-	$theme = sanitize_text_field( wp_unslash( $_GET['theme'] ) );
-	if ( ! str_contains( $theme, '-did--' ) ) {
-		return;
-	}
-
-	$did = 'did:' . explode( '-did:', str_replace( '--', ':', $theme ), 2 )[1];
-	if ( ! preg_match( '/^did:plc:.+$/', $did ) ) {
-		return;
-	}
-
-	$hashed_theme = explode( '-did--', $theme, 2 )[0] . '-' . Packages\get_did_hash( $did );
-	$_GET['theme'] = $hashed_theme;
-	$_REQUEST['theme'] = $hashed_theme;
+	return $url;
 }
 
 /**

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -495,23 +495,20 @@ function handle_did_in_search_results( $res, $action, $args ) {
 	$type = explode( '_', $action )[1];
 
 	if (
-		( $type === 'plugin' && empty( $res->plugins ) )
-		|| ( $type === 'theme' && empty( $res->themes ) )
+		( $type === 'plugins' && empty( $res->plugins ) )
+		|| ( $type === 'themes' && empty( $res->themes ) )
 	) {
 		return $res;
 	}
 
-<<<<<<< HEAD
 	// Alter the slugs to our globally unique version and populate release cache.
-	$items = $type === 'plugin' ? $res->plugins : $res->themes;
-
-	// Alter the slugs to our globally unique version.
+	$items = $type === 'plugins' ? $res->plugins : $res->themes;
 	foreach ( $items as &$item ) {
 		if ( ! is_fair_package( $item ) ) {
 			continue;
 		}
 
-		if ( $type === 'plugin' ) {
+		if ( $type === 'plugins' ) {
 			$did = $item['_fair']['id'];
 			$item['slug'] = esc_attr( $item['slug'] . '-' . str_replace( ':', '--', $did ) );
 		} else {

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -43,6 +43,7 @@ function bootstrap() {
 	add_filter( 'themes_api', __NAMESPACE__ . '\\handle_did_during_ajax', 10, 3 );
 	add_filter( 'themes_api', 'FAIR\\Packages\\search_by_did', 10, 3 );
 	add_filter( 'themes_api_result', __NAMESPACE__ . '\\alter_slugs', 10, 3 );
+	add_action( 'load-themes.php', __NAMESPACE__ . '\\set_stylesheet_to_hashed_on_theme_activation' );
 
 	// Common.
 	add_filter( 'upgrader_package_options', 'FAIR\\Packages\\cache_did_for_install', 10, 1 );
@@ -304,6 +305,46 @@ function set_slug_to_hashed() : void {
 
 	// Reset to proper hashed slug.
 	$_POST['slug'] = explode( '-did--', $escaped_slug, 2 )[0] . '-' . Packages\get_did_hash( $did );
+}
+
+/**
+ * Set the stylesheet to the hashed version on theme activation.
+ *
+ * After installing a theme via AJAX, the activation button's link
+ * includes the escaped DID, not the hash of the DID.
+ *
+ * The stylesheet parameter needs to be in the slug-didhash format
+ * so that the theme can be found.
+ *
+ * The nonce also needs to be regenerated as the action includes
+ * the stylesheet.
+ *
+ * @return void
+ */
+function set_stylesheet_to_hashed_on_theme_activation() {
+	// phpcs:ignore HM.PHP.Isset.MultipleArguments
+	if ( ! isset( $_GET['action'], $_GET['stylesheet'] ) || $_GET['action'] !== 'activate' ) {
+		return;
+	}
+
+	$stylesheet = sanitize_text_field( wp_unslash( $_GET['stylesheet'] ) );
+	check_admin_referer( 'switch-theme_' . $stylesheet );
+
+	if ( ! str_contains( $stylesheet, '-did--' ) ) {
+		return;
+	}
+
+	$did = 'did:' . explode( '-did:', str_replace( '--', ':', $stylesheet ), 2 )[1];
+	if ( ! preg_match( '/^did:plc:.+$/', $did ) ) {
+		return;
+	}
+
+	$hashed_stylesheet = explode( '-did--', $stylesheet, 2 )[0] . '-' . Packages\get_did_hash( $did );
+	$_GET['stylesheet'] = $hashed_stylesheet;
+	$_REQUEST['stylesheet'] = $hashed_stylesheet;
+	$new_nonce = wp_create_nonce( 'switch-theme_' . $hashed_stylesheet );
+	$_GET['_wpnonce'] = $new_nonce;
+	$_REQUEST['_wpnonce'] = $new_nonce;
 }
 
 /**

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -492,23 +492,23 @@ function handle_did_in_search_results( $res, $action, $args ) {
 		return $res;
 	}
 
-	$type = explode( '_', $action )[1];
+	$type = rtrim( explode( '_', $action )[1], 's' );
 
 	if (
-		( $type === 'plugins' && empty( $res->plugins ) )
-		|| ( $type === 'themes' && empty( $res->themes ) )
+		( $type === 'plugin' && empty( $res->plugins ) )
+		|| ( $type === 'theme' && empty( $res->themes ) )
 	) {
 		return $res;
 	}
 
 	// Alter the slugs to our globally unique version and populate release cache.
-	$items = $type === 'plugins' ? $res->plugins : $res->themes;
+	$items = $type === 'plugin' ? $res->plugins : $res->themes;
 	foreach ( $items as &$item ) {
 		if ( ! is_fair_package( $item ) ) {
 			continue;
 		}
 
-		if ( $type === 'plugins' ) {
+		if ( $type === 'plugin' ) {
 			$did = $item['_fair']['id'];
 			$item['slug'] = esc_attr( $item['slug'] . '-' . str_replace( ':', '--', $did ) );
 		} else {

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -111,13 +111,13 @@ function replace_featured_message() {
 /**
  * Handles the AJAX request for plugin information when a DID is present.
  *
- * @param mixed  $result The result of the plugins_api call.
+ * @param mixed  $result The result of the API call.
  * @param string $action The action being performed.
- * @param object $args   The arguments passed to the plugins_api call.
+ * @param object $args   The arguments passed to the API call.
  * @return mixed
  */
 function handle_did_during_ajax( $result, $action, $args ) {
-	if ( ! wp_doing_ajax() || 'plugin_information' !== $action || ! isset( $args->slug ) ) {
+	if ( ! wp_doing_ajax() || ! isset( $args->slug ) || ( 'plugin_information' !== $action && 'theme_information' !== $action ) ) {
 		return $result;
 	}
 

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -509,8 +509,8 @@ function handle_did_in_search_results( $res, $action, $args ) {
 		}
 
 		if ( $type === 'plugin' ) {
-			$did = $item['_fair']['id'];
-			$item['slug'] = esc_attr( $item['slug'] . '-' . str_replace( ':', '--', $did ) );
+			$did = $item->_fair['id'];
+			$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 		} else {
 			// Installed themes need to have the slug-didhash format
 			// so their activation status can be determined.

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -622,8 +622,8 @@ function maybe_add_data_to_description( $description, $plugin ) {
 		return $description;
 	}
 
-	/* translators: %1$s: repository hostname */
-	$description .= '</p><p class="authors"><em>' . sprintf( __( 'Hosted on %1$s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
+	/* translators: %s: repository hostname */
+	$description .= '</p><p class="authors"><em>' . sprintf( __( 'Hosted on %s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
 	return $description;
 }
 
@@ -645,8 +645,8 @@ function maybe_add_data_to_theme_description( $themes ) {
 			continue;
 		}
 
-		/* translators: %1$s: repository hostname */
-		$additional_description = '<p class="authors"><em>' . sprintf( __( 'Hosted on %1$s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
+		/* translators: %s: repository hostname */
+		$additional_description = '<p class="authors"><em>' . sprintf( __( 'Hosted on %s', 'fair' ), esc_html( $repo_host ) ) . '</em>';
 		if ( empty( $theme->description ) ) {
 			$theme['description'] .= '</p>' . $additional_description;
 		} else {

--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -508,29 +508,25 @@ function handle_did_in_search_results( $res, $action, $args ) {
 			continue;
 		}
 
-		if ( $type === 'plugin' ) {
-			$did = $item->_fair['id'];
-			$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
-		} else {
-			// Installed themes need to have the slug-didhash format
-			// so their activation status can be determined.
-			$did_hash = Packages\get_did_hash( $item->_fair['id'] );
-			$slug = $item->slug;
-			if ( ! str_ends_with( $slug, '-' . $did_hash ) ) {
-				$slug = $item->slug . '-' . $did_hash;
-			}
+		$did = $item->_fair['id'];
+		$did_hash = Packages\get_did_hash( $item->_fair['id'] );
+		$slug = $item->slug;
+		if ( ! str_ends_with( $slug, '-' . $did_hash ) ) {
+			$slug = $item->slug . '-' . $did_hash;
+		}
+
+		// Installed themes need the slug-didhash format
+		// so their activation status can be determined.
+		if ( 'theme' === $type ) {
 			$theme = wp_get_theme( $slug );
 			if ( $theme->exists() ) {
 				$item->slug = esc_attr( $slug );
 				continue;
 			}
-
-			// Themes that aren't installed need the slug--escaped-did format
-			// so their metadata can be retrieved.
-			$did = $item->_fair['id'];
-			$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 		}
 		Packages\add_package_to_release_cache( $did );
+
+		$item->slug = esc_attr( $item->slug . '-' . str_replace( ':', '--', $did ) );
 	}
 
 	return $res;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -697,9 +697,6 @@ function get_package_data( $did ) {
 		$response['author'] = [
 			'display_name' => $metadata->authors[0]->name,
 		];
-	} else {
-		$response['author'] = $metadata->authors[0]->name;
-		$response['author_uri'] = $metadata->authors[0]->url;
 	}
 
 	return $response;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -697,6 +697,9 @@ function get_package_data( $did ) {
 		$response['author'] = [
 			'display_name' => $metadata->authors[0]->name,
 		];
+	} else {
+		$response['author'] = $metadata->authors[0]->name;
+		$response['author_uri'] = $metadata->authors[0]->url;
 	}
 
 	return $response;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -665,8 +665,6 @@ function get_package_data( $did ) {
 
 	$response = [
 		'name'              => $metadata->name,
-		'author'            => $metadata->authors[0]->name,
-		'author_uri'        => $metadata->authors[0]->url,
 		'slug'              => $metadata->slug,
 		'slug_didhash'      => $metadata->slug . '-' . get_did_hash( $did ),
 		$type               => $filename,
@@ -695,6 +693,12 @@ function get_package_data( $did ) {
 	];
 	if ( 'theme' === $type ) {
 		$response['theme_uri'] = $response['url'];
+		$response['author'] = [
+			'display_name' => $metadata->authors[0]->name,
+		];
+	} else {
+		$response['author'] = $metadata->authors[0]->name;
+		$response['author_uri'] = $metadata->authors[0]->url;
 	}
 
 	return $response;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -1020,13 +1020,13 @@ function fetch_and_validate_package_alias( DIDDocument $did ) {
 /**
  * Enable searching by DID.
  *
- * @param mixed  $result The result of the plugins_api call.
+ * @param mixed  $result The result of the API call.
  * @param string $action The action being performed.
- * @param stdClass $args The arguments passed to the plugins_api call.
+ * @param stdClass $args The arguments passed to the API call.
  * @return mixed The search result for the DID.
  */
 function search_by_did( $result, $action, $args ) {
-	if ( 'query_plugins' !== $action || empty( $args->search ) ) {
+	if ( empty( $args->search ) || ( 'query_plugins' !== $action && 'query_themes' !== $action ) ) {
 		return $result;
 	}
 
@@ -1041,8 +1041,9 @@ function search_by_did( $result, $action, $args ) {
 		return $result;
 	}
 
+	$type = explode( '_', $action )[1];
 	$result = [
-		'plugins' => [ $api_data ],
+		$type => [ $type === 'plugin' ? $api_data : (object) $api_data ],
 		'info' => [
 			'page' => 1,
 			'pages' => 1,

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -693,6 +693,7 @@ function get_package_data( $did ) {
 	];
 	if ( 'theme' === $type ) {
 		$response['theme_uri'] = $response['url'];
+		$response['preview_url'] = $metadata->url ?? '';
 		$response['author'] = [
 			'display_name' => $metadata->authors[0]->name,
 		];

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -219,7 +219,12 @@ class Updater {
 			return $result;
 		}
 
-		return (object) Packages\get_package_data( $this->did );
+		$package_data = (object) Packages\get_package_data( $this->did );
+		if ( $this->type === 'theme' ) {
+			$package_data->author = $package_data->author['display_name'];
+		}
+
+		return $package_data;
 	}
 
 	/**

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -236,12 +236,17 @@ class Updater {
 		}
 
 		$rel_path = plugin_basename( $this->filepath );
-		$rel_path = 'theme' === $this->type ? dirname( $rel_path ) : $rel_path;
+		$rel_path = 'theme' === $this->type ? basename( dirname( $rel_path ) ) : $rel_path;
 		$response = Packages\get_package_data( $this->did );
 		if ( is_wp_error( $response ) ) {
 			return $transient;
 		}
-		$response['slug'] = $response['slug_didhash'];
+		// $response['slug'] = $response['slug_didhash'];
+		// Delete any existing update for this package if non-hashed slug.
+		// Avoids duplicate update theme entries.
+		if ( 'theme' === $this->type && $response['file'] === $rel_path ) {
+			unset( $transient->response[ $response['slug'] ] );
+		}
 		$response = 'plugin' === $this->type ? (object) $response : $response;
 		$is_compatible = Packages\check_requirements( $this->release );
 
@@ -265,13 +270,12 @@ class Updater {
 	 * @return array
 	 */
 	public function customize_theme_update_html( $prepared_themes ) {
-		$theme = $this->metadata;
-
 		if ( 'theme' !== $this->type ) {
 			return $prepared_themes;
 		}
 
 		$did_hash = Packages\get_did_hash( $this->did );
+		$theme = (object) Packages\get_package_data( $this->did );
 		if ( ! str_ends_with( $theme->slug, '-' . $did_hash ) ) {
 			$theme->slug = $theme->slug . '-' . $did_hash;
 		}

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -246,7 +246,6 @@ class Updater {
 		if ( is_wp_error( $response ) ) {
 			return $transient;
 		}
-		// $response['slug'] = $response['slug_didhash'];
 		// Delete any existing update for this package if non-hashed slug.
 		// Avoids duplicate update theme entries.
 		if ( 'theme' === $this->type && $response['file'] === $rel_path ) {

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -222,6 +222,7 @@ class Updater {
 		$package_data = (object) Packages\get_package_data( $this->did );
 		if ( $this->type === 'theme' ) {
 			$package_data->author = $package_data->author['display_name'];
+			$package_data->slug = $package_data->slug_didhash;
 		}
 
 		return $package_data;

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -282,7 +282,7 @@ class Updater {
 		$did_hash = Packages\get_did_hash( $this->did );
 		$theme = (object) Packages\get_package_data( $this->did );
 		if ( ! str_ends_with( $theme->slug, '-' . $did_hash ) ) {
-			$theme->slug = $theme->slug . '-' . $did_hash;
+			$theme->slug = array_key_exists( $theme->slug, $prepared_themes ) ? $theme->slug : $theme->slug . '-' . $did_hash;
 		}
 
 		if ( ! empty( $prepared_themes[ $theme->slug ]['hasUpdate'] ) ) {

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -271,6 +271,11 @@ class Updater {
 			return $prepared_themes;
 		}
 
+		$did_hash = Packages\get_did_hash( $this->did );
+		if ( ! str_ends_with( $theme->slug, '-' . $did_hash ) ) {
+			$theme->slug = $theme->slug . '-' . $did_hash;
+		}
+
 		if ( ! empty( $prepared_themes[ $theme->slug ]['hasUpdate'] ) ) {
 			$prepared_themes[ $theme->slug ]['update'] = $this->append_theme_actions_content( $theme );
 		} else {


### PR DESCRIPTION
We've mostly been testing with plugins up until now. As a result, some of our features either don't support themes at all, or don't handle the differences between plugins and themes.

I used a test theme, `did:plc:fbiuevja7wpvkgkh4zcswe4r`, to step through admin-based theme handling.

This PR:
- Renames `is_fair_plugin()` to `is_fair_package()`.
- Organizes the plugins, themes, and common hooks.
- Extends "Search by DID" support to themes.
- Extends AJAX DID support to themes.
- Extends `rename_source_selection` support to themes so a theme is also installed under the correct directory name.
- Adds missing properties (`preview_url`)
- Corrects the shape of the `author` property for themes (yep, plugins and themes have different shapes).
- Adds the hostname, if available, to the theme's description when preparing themes for JS. (View in modal).
- Adds support for "Live Preview" immediately after installation.

### Reviewers
~Blocked by structural changes made in #277. I'd suggest not to review this PR until that's been merged and this PR is rebased on `main`. However, if you _really_ want to review it, then you're looking at "Rename is_fair_plugin() to is_fair_package()." (`070b72b`) onwards.~

Update: #277 is merged. Go ahead and review!

### Testers
You can go ahead and test this PR either locally, or in the Playground link below. Note that modal-based interactions _may_ not work correctly in Playground, which is a Playground issue.

You can test using this DID: `did:plc:fbiuevja7wpvkgkh4zcswe4r`