### PR TITLE
Add more data to get_package_data(), renamed from get_update_data()

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -97,7 +97,7 @@ function handle_did_during_ajax( $result, $action, $args ) {
 	Packages\add_package_to_release_cache( $did );
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
 
-	return (object) Packages\get_update_data( $did );
+	return (object) Packages\get_package_data( $did );
 }
 
 /**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -931,7 +931,8 @@ function get_api_data( $did ) {
 		return $api_data;
 	}
 
-	$api_data = json_decode( json_encode( $api_data ), true );
+	// Convert the MetadataDocument to an array for compatibility.
+	$api_data['_fair'] = json_decode( json_encode( $api_data['_fair'] ), true );
 
 	return $api_data;
 }

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -219,7 +219,7 @@ class Updater {
 			return $result;
 		}
 
-		return (object) Packages\get_update_data( $this->did );
+		return (object) Packages\get_package_data( $this->did );
 	}
 
 	/**
@@ -237,7 +237,7 @@ class Updater {
 
 		$rel_path = plugin_basename( $this->filepath );
 		$rel_path = 'theme' === $this->type ? dirname( $rel_path ) : $rel_path;
-		$response = Packages\get_update_data( $this->did );
+		$response = Packages\get_package_data( $this->did );
 		if ( is_wp_error( $response ) ) {
 			return $transient;
 		}


### PR DESCRIPTION
Rename `get_update_data()` to `get_package_data()`.

Add data elements needed for `plugins_api` or `themes_api` filter.