### PR TITLE
Don't create a bundle for versions older than FAIR supports

### DIFF
--- a/bin/bundle.sh
+++ b/bin/bundle.sh
@@ -22,7 +22,7 @@ touch /tmp/fair-dist/SHA384SUMS
 # Bundle our plugin first.
 [ -d /tmp/fair-temp ] && rm -rf /tmp/fair-temp
 mkdir -p /tmp/fair-temp/wordpress/wp-content/plugins/fair-plugin
-rsync -a --exclude-from="$SCRIPT_DIR/../.distignore" "$SCRIPT_DIR/.." /tmp/fair-temp/wordpress/wp-content/plugins/fair-plugin
+rsync -a --exclude-from="$SCRIPT_DIR/../.distignore" "$SCRIPT_DIR/../" /tmp/fair-temp/wordpress/wp-content/plugins/fair-plugin
 
 # Extract minimum required WordPress version from plugin header.
 REQUIRES_AT_LEAST=$(get_plugin_header "Requires at least")


### PR DESCRIPTION
The bundles created for the release bundle FAIR with every version of WordPress back to 4.7, but FAIR only supports 5.4 and higher.

This adjusts the bundle script so it skips bundles for unsupported versions of WordPress, and fixes a path issue which was preventing `rsync` from running on my macOS machine.

## Steps to test:

1. Run `./bin/bundle.sh`
2. Confirm the output shows that older versions were skipped:

```
Skipping 5.3.20 (older than 5.4)
Skipping 5.2.23 (older than 5.4)
Skipping 5.1.21 (older than 5.4)
Skipping 5.0.24 (older than 5.4)
Skipping 4.9.28 (older than 5.4)
Skipping 4.8.27 (older than 5.4)
Skipping 4.7.31 (older than 5.4)
```