### PR TITLE
fix duplicate entries in featured tab

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -43,7 +43,7 @@ function bootstrap() {
 	// Needed for pre WordPress 6.9 compatibility.
 	global $wp_version;
 	if ( version_compare( $wp_version, '6.9-beta1', '<' ) ) {
-		add_action( 'install_plugins_featured', __NAMESPACE__ . '\\replace_featured_message', 10 );
+		add_action( 'install_plugins_featured', __NAMESPACE__ . '\\replace_featured_message' );
 		add_action( 'admin_init', fn() => remove_action( 'install_plugins_featured', 'install_dashboard' ) );
 	}
 }


### PR DESCRIPTION
Fixes a set of duplicate plugin cards on the Add Plugins page under Featured tab for pre-WP6.9