### PR TITLE
Parse IndexNow request earlier.

### DIFF
--- a/inc/pings/namespace.php
+++ b/inc/pings/namespace.php
@@ -97,6 +97,7 @@ function handle_key_file_request( $wp ) {
 	header( 'Content-Type: text/plain' );
 	header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + YEAR_IN_SECONDS ) . ' GMT' );
 	header( 'Cache-Control: public, max-age=' . YEAR_IN_SECONDS );
+	header( 'X-Robots-Tag: noindex' );
 
 	// Output the key.
 	echo esc_html( $key );


### PR DESCRIPTION
* Moves the handling of the IndexNow key request from the `template_redirect` hook to the `parse_request` hook. This improves performance of the request by bypassing unneeded database queries.
* Adds an X-Robots-Tag header to ensure the requests aren't indexed by search engines.

Fixes #162.

If you have a change request and it's more convenient to push to my branch, feel free to do so.