### PR TITLE
Skip IndexNow notifications during imports.

### DIFF
--- a/inc/pings/namespace.php
+++ b/inc/pings/namespace.php
@@ -109,6 +109,11 @@ function handle_key_file_request() {
  * @param WP_Post $post       Post object.
  */
 function ping_indexnow( $new_status, $old_status, $post ) : void {
+	// Skip during imports to avoid flooding IndexNow.
+	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+		return;
+	}
+
 	// Skip if the post isn't viewable.
 	if ( ! is_post_type_viewable( $post->post_type ) || ! is_post_status_viewable( $new_status ) ) {
 		return;


### PR DESCRIPTION
Bypassing pinging of IndexNow during imports.

Pinging IndexNow during an import can flood the service with notifications of new URLs and rapidly use up a site's allowance resulting in `429 Too Many Requests` responses from IndexNow.

Fixes #176.

cc @joedolson as you've self assigned the ticket.