### PR TITLE
Link to the FAIRPM repo's discussions section.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions
-    url: https://github.com/orgs/upptime/discussions/new?category=q-a
+    url: https://github.com/orgs/fairpm/discussions/new?category=q-a
     about: Ask and answer questions about FAIR here


### PR DESCRIPTION
This PR updates the link for the "Questions" issue type to point to the FAIRPM repo's discussions section.