### PR TITLE
Add RELEASE.md documenting the version release process

### DIFF
--- a/RELEASE.MD
+++ b/RELEASE.MD
@@ -70,7 +70,7 @@ Once the milestone contains no open issues or pull requests, the release is read
 2. Click the **Draft a new release** button.
 
 3. In the **Select tag** field:
-    - Select the tag that matches the version you just released (e.g., `1.2.0`).
+    - Select the tag that matches the version you just bumped to (e.g., `1.2.0`).
     - Create a new tag if it does not appear in the dropdown.
 
 4. In the **Release title** field, enter a title for the release (e.g., `1.2.0`).


### PR DESCRIPTION
This PR adds `RELEASE.md`, which documents the full maintainer release workflow for FAIR Connect.  

The guide provides step-by-step instructions for running release-related workflows, reviewing and merging automated PRs, updating POT files, creating GitHub releases, and performing optional milestone cleanup.

The goal is to ensure a consistent, repeatable release process and to make onboarding easier for future maintainers.

### Included in this PR
- New `RELEASE.md` file
- Full documentation of the version bump workflow
- Instructions for reviewing and merging automated PRs
- Guidance for generating and publishing GitHub releases
- Optional milestone cleanup procedures

### Additional improvements that may be added before merging
- Confirm Generate POT workflow (👀 @afragen, @costdev)
- Insert screenshots into the `RELEASE.md` document to supplement written steps.

### Future enhancements (out of scope for this PR)
- Add documentation describing the GitHub workflows and automations that power the release process.

Fixes #354 