### PR TITLE
Fix modal for empty $sections

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -126,7 +126,7 @@ function render_page( MetadataDocument $metadata, string $tab, string $section )
 function render( MetadataDocument $doc, string $tab, string $section ) {
 	$sections = (array) $doc->sections;
 
-	if ( ! isset( $sections[ $section ] ) ) {
+	if ( ! isset( $sections[ $section ] ) && ! empty( $sections ) ) {
 		$section = array_keys( $sections )[0];
 	}
 


### PR DESCRIPTION
Fixes the View details modal when no sections data is present. See current Query Monitor.