### PR TITLE
Update jdecked/twemoji to 17.0.2.

### DIFF
--- a/inc/assets/namespace.php
+++ b/inc/assets/namespace.php
@@ -7,7 +7,7 @@
 
 namespace FAIR\Assets;
 
-const DEFAULT_EMOJI_BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/';
+const DEFAULT_EMOJI_BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/';
 
 /**
  * Bootstrap.


### PR DESCRIPTION
This PR updates jdecked/twemoji to the latest version, [17.0.2](https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/).

Props to @Presskopp for the precursor to this PR, #181