### PR TITLE
Workflows: Add WP 6.8, 6.9 and PHP 8.5 to PHPUnit tests.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,9 +35,41 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
-        wp-version: [ '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7' ]
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        wp-version: [ '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9' ]
         exclude:
+          # PHP 8.5 exclusions
+          - wp-version: '6.8'
+            php-version: '8.5'
+          - wp-version: '6.7'
+            php-version: '8.5'
+          - wp-version: '6.6'
+            php-version: '8.5'
+          - wp-version: '6.5'
+            php-version: '8.5'
+          - wp-version: '6.4'
+            php-version: '8.5'
+          - wp-version: '6.3'
+            php-version: '8.5'
+          - wp-version: '6.2'
+            php-version: '8.5'
+          - wp-version: '6.1'
+            php-version: '8.5'
+          - wp-version: '6.0'
+            php-version: '8.5'
+          - wp-version: '5.9'
+            php-version: '8.5'
+          - wp-version: '5.8'
+            php-version: '8.5'
+          - wp-version: '5.7'
+            php-version: '8.5'
+          - wp-version: '5.6'
+            php-version: '8.5'
+          - wp-version: '5.5'
+            php-version: '8.5'
+          - wp-version: '5.4'
+            php-version: '8.5'
+
           # PHP 8.4 exclusions
           - wp-version: '6.6'
             php-version: '8.4'


### PR DESCRIPTION
This adds WordPress 6.8, 6.9 and PHP 8.5 to the matrix in the PHPUnit workflow.

Exclusions are also in place for PHP 8.5 and any WP version below 6.9, which [introduced PHP 8.5 beta support](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/#supported-version-chart)