### PR TITLE
Pass 4 arguments to `maybe_rename_on_package_download`.

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -710,7 +710,7 @@ function get_package_data( $did ) {
  */
 function upgrader_pre_download( $false ) : bool {
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
-	add_filter( 'upgrader_source_selection', __NAMESPACE__ . '\\maybe_rename_on_package_download', 11, 3 );
+	add_filter( 'upgrader_source_selection', __NAMESPACE__ . '\\maybe_rename_on_package_download', 11, 4 );
 	return $false;
 }
 


### PR DESCRIPTION
#378 added a fourth `$hook_extra` parameter to `FAIR\Packages\maybe_rename_on_package_download`, but didn't update the `$accepted_args` argument [when adding the callback](https://github.com/fairpm/fair-plugin/blob/ba4bf9d5870542aa9f289c2227352d6033148383/inc/packages/namespace.php#L713), causing a fatal error due to an insufficient argument count.

This PR increases the `$accepted_args` argument from `3` to `4` so that the expected number of arguments will be passed, resolving the fatal error.

---

Fixes #393 