### PR TITLE
Copy plugin release zip to Fastly object storage

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -38,8 +38,10 @@ jobs:
             /tmp/fair-dist/*
 
       - name: Upload to Fastly Object Storage
-        run:
-          aws s3 cp /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip s3://download.fair.pm//${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+        # note the plugin filename is always 'fair-connect', regardless of the repo name or slug
+        run: |
+          aws s3 cp /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip s3://download.fair.pm/release/fair-connect-${{ steps.tag.outputs.tag }}.zip
+          aws s3 cp --recursive --exclude '*'  --include '*.zip' /tmp/fair-dist s3://download.fair.pm/release/
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOWNLOAD_BUCKET_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOWNLOAD_BUCKET_SECRET_KEY }}


### PR DESCRIPTION
I've tested the command in isolation, and it's known to work, but the only real way to test the action is to just tag a test release and let it do its thing.  We can use a tag like `0.0.1-exp` which has no danger of causing an update, and remove it after.

This address part of #411 but does not close it.
