### PR TITLE
Add guard to anonymous function

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -727,6 +727,9 @@ function cache_did_for_install( array $options ): array {
 		$did = array_find_key(
 			$releases,
 			function ( $release ) use ( $options ) {
+				if ( ! is_array( $release->artifacts->package ) ) {
+					return false;
+				}
 				$artifact = pick_artifact_by_lang( $release->artifacts->package );
 				return $artifact && $artifact->url === $options['package'];
 			}


### PR DESCRIPTION
Fixes #412

Somehow `release->artifacts->package` is null and sending to `pick_artifact_by_lang()` returns a type error. Adding a guard to the anonymous function should mitigate this issue.