### PR TITLE
Fix syntax error in hash validation condition in bundle.sh

### DIFF
--- a/bin/bundle.sh
+++ b/bin/bundle.sh
@@ -71,7 +71,7 @@ for VERSION in $AVAILABLE_VERSIONS; do
 	EXPECTED_HASH=$(curl -sSL "$WP_ZIP_URL.sha1")
 
 	# Skip if we can't get a valid hash.
-	if ![[ $EXPECTED_HASH =~ ^[a-z0-9]{40}$ ]]; then
+	if ! [[ $EXPECTED_HASH =~ ^[a-z0-9]{40}$ ]]; then
 		echo "Failed to fetch valid hash for $VERSION" >&2
 		continue
 	fi


### PR DESCRIPTION
On line 74 the condition is written as if `![[ $EXPECTED_HASH =~ ... ]]`. There is no space between `!` and `[[`. 

In bash, `!` immediately followed by `[` is treated as history expansion ( `![ = “last command starting with [”`). In a non-interactive environment like Github Actions, that expansion fails or yields something that is not a valid command, so the shell reports “command not found."

Signed-off-by: Mika Epstein ipstenu@halfelf.org