### PR TITLE
Update stable tag version to 1.4.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: packages, updater, installer, technical independence
 Requires at least: 5.4
 Requires PHP: 7.4
 Tested up to: 6.9
-Stable tag: 1.1.0
+Stable tag: 1.3.0
 
 FAIR is a system for using **F**ederated **a**nd **I**ndependent **R**epositories in WordPress.
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: packages, updater, installer, technical independence
 Requires at least: 5.4
 Requires PHP: 7.4
 Tested up to: 6.9
-Stable tag: 1.3.0
+Stable tag: 1.4.0
 
 FAIR is a system for using **F**ederated **a**nd **I**ndependent **R**epositories in WordPress.
 


### PR DESCRIPTION
The stable version in readme.txt has been updated to the current version of the plugin.