### PR TITLE
add error checking in add_package_to_release_cache()

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -938,6 +938,9 @@ function add_package_to_release_cache( string $did ) : void {
 	}
 	$releases = get_site_transient( CACHE_RELEASE_PACKAGES ) ?: [];
 	$releases[ $did ] = get_latest_release_from_did( $did );
+	if ( is_wp_error( $releases[ $did ] ) ) {
+		unset( $releases[ $did ] );
+	}
 	set_site_transient( CACHE_RELEASE_PACKAGES, $releases );
 }
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -936,13 +936,13 @@ function add_package_to_release_cache( string $did ) : void {
 	if ( empty( $did ) ) {
 		return;
 	}
- 	$latest_release = get_latest_release_from_did( $did );
+	$latest_release = get_latest_release_from_did( $did );
 	if ( is_wp_error( $latest_release ) ) {
 		return;
 	}
- 	$releases = get_site_transient( CACHE_RELEASE_PACKAGES ) ?: [];
- 	$releases[ $did ] = $latest_release;
- 	set_site_transient( CACHE_RELEASE_PACKAGES, $releases );
+	$releases = get_site_transient( CACHE_RELEASE_PACKAGES ) ?: [];
+	$releases[ $did ] = $latest_release;
+	set_site_transient( CACHE_RELEASE_PACKAGES, $releases );
 }
 
 /**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -936,12 +936,13 @@ function add_package_to_release_cache( string $did ) : void {
 	if ( empty( $did ) ) {
 		return;
 	}
-	$releases = get_site_transient( CACHE_RELEASE_PACKAGES ) ?: [];
-	$releases[ $did ] = get_latest_release_from_did( $did );
-	if ( is_wp_error( $releases[ $did ] ) ) {
-		unset( $releases[ $did ] );
+ 	$latest_release = get_latest_release_from_did( $did );
+	if ( is_wp_error( $latest_release ) ) {
+		return;
 	}
-	set_site_transient( CACHE_RELEASE_PACKAGES, $releases );
+ 	$releases = get_site_transient( CACHE_RELEASE_PACKAGES ) ?: [];
+ 	$releases[ $did ] = $latest_release;
+ 	set_site_transient( CACHE_RELEASE_PACKAGES, $releases );
 }
 
 /**


### PR DESCRIPTION
Add error checking to `Packages::add_package_to_release_cache()`.

Don't save a WP_Error to the cache. `Packages::get_latest_release_from_did()` can return a WP_Error. We need to account for that.