### PR TITLE
Release 1.4.0

### DIFF
--- a/.github/workflows/publish-fair.yml
+++ b/.github/workflows/publish-fair.yml
@@ -1,8 +1,9 @@
 name: Publish FAIR Metadata
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_run:
+    workflows: ["Upload Release Asset"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -16,17 +17,27 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Get tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.version }}" ]]; then
+            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to FAIR
         uses: fairpm/fair-pulse@v1
         with:
-          version: ${{ inputs.version }}
-          artifact-name: my-plugin.zip
+          version: ${{ steps.tag.outputs.tag }}
+          artifact-name: ${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
           upload-metadata: 'true'
         env:
           FAIR_VERIFICATION_KEY_PRIVATE: ${{ secrets.FAIR_VERIFICATION_KEY_PRIVATE }}


### PR DESCRIPTION
Modified the Fair Publish workflow to use the already available release asset instead of generating a new one.  Also modified the workflow to only run if the Publish Release workflow which creates the current release asset completes successfully.