### PR TITLE
Remove < PHP 8.0 & WP 6.2 from test matrix

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
-        wp-version: [ '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        wp-version: [ '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9' ]
         exclude:
           # PHP 8.5 exclusions
           - wp-version: '6.8'
@@ -53,22 +53,6 @@ jobs:
             php-version: '8.5'
           - wp-version: '6.2'
             php-version: '8.5'
-          - wp-version: '6.1'
-            php-version: '8.5'
-          - wp-version: '6.0'
-            php-version: '8.5'
-          - wp-version: '5.9'
-            php-version: '8.5'
-          - wp-version: '5.8'
-            php-version: '8.5'
-          - wp-version: '5.7'
-            php-version: '8.5'
-          - wp-version: '5.6'
-            php-version: '8.5'
-          - wp-version: '5.5'
-            php-version: '8.5'
-          - wp-version: '5.4'
-            php-version: '8.5'
 
           # PHP 8.4 exclusions
           - wp-version: '6.6'
@@ -81,84 +65,12 @@ jobs:
             php-version: '8.4'
           - wp-version: '6.2'
             php-version: '8.4'
-          - wp-version: '6.1'
-            php-version: '8.4'
-          - wp-version: '6.0'
-            php-version: '8.4'
-          - wp-version: '5.9'
-            php-version: '8.4'
-          - wp-version: '5.8'
-            php-version: '8.4'
-          - wp-version: '5.7'
-            php-version: '8.4'
-          - wp-version: '5.6'
-            php-version: '8.4'
-          - wp-version: '5.5'
-            php-version: '8.4'
-          - wp-version: '5.4'
-            php-version: '8.4'
 
           # PHP 8.3 exclusions
           - wp-version: '6.3'
             php-version: '8.3'
           - wp-version: '6.2'
             php-version: '8.3'
-          - wp-version: '6.1'
-            php-version: '8.3'
-          - wp-version: '6.0'
-            php-version: '8.3'
-          - wp-version: '5.9'
-            php-version: '8.3'
-          - wp-version: '5.8'
-            php-version: '8.3'
-          - wp-version: '5.7'
-            php-version: '8.3'
-          - wp-version: '5.6'
-            php-version: '8.3'
-          - wp-version: '5.5'
-            php-version: '8.3'
-          - wp-version: '5.4'
-            php-version: '8.3'
-
-          # PHP 8.2 exclusions
-          - wp-version: '6.0'
-            php-version: '8.2'
-          - wp-version: '5.9'
-            php-version: '8.2'
-          - wp-version: '5.8'
-            php-version: '8.2'
-          - wp-version: '5.7'
-            php-version: '8.2'
-          - wp-version: '5.6'
-            php-version: '8.2'
-          - wp-version: '5.5'
-            php-version: '8.2'
-          - wp-version: '5.4'
-            php-version: '8.2'
-
-          # PHP 8.1 exclusions
-          - wp-version: '5.8'
-            php-version: '8.1'
-          - wp-version: '5.7'
-            php-version: '8.1'
-          - wp-version: '5.6'
-            php-version: '8.1'
-          - wp-version: '5.5'
-            php-version: '8.1'
-          - wp-version: '5.4'
-            php-version: '8.1'
-
-          # PHP 8 exclusions
-          - wp-version: '5.8' # Should work, currently doesn't.
-            php-version: '8.0'
-          - wp-version: '5.7' # Should work, currently doesn't.
-            php-version: '8.0'
-          - wp-version: '5.6' # Introduced PHP 8 beta support. Should work, currently doesn't.
-            php-version: '8.0'
-          - wp-version: '5.5'
-            php-version: '8.0'
-          - wp-version: '5.4'
-            php-version: '8.0'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Removes versions of PHP that we don't support and WordPress versions older than 6.2 from the test matrix.