### PR TITLE
Update composer deps instead of install

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -96,7 +96,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --optimize-autoloader --prefer-dist
+        run: composer update --optimize-autoloader --prefer-dist
 
       - name: Install SVN
         run: sudo apt-get update && sudo apt-get install -y subversion


### PR DESCRIPTION
Some dependencies expect higher versions of PHP than the installed environments. This will update the composer.lock file so the installed versions of the composer dependencies are updated based on the installed version of PHP running in the environment. 

Since this is just for testing, there's no risk for any downstream changes to the plugin.