### PR TITLE
remove check for modified files

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -113,6 +113,3 @@ jobs:
         run: |
           echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> ${{ runner.temp }}/wordpress-tests-lib/wp-tests-config.php
           phpunit
-
-      - name: Ensure version-controlled files are not modified or deleted
-        run: git diff --exit-code


### PR DESCRIPTION
This removes the check at the end of the tests for modified version controlled files. This check fails because we update the composer.lock file on < PHP 8.2 environments. This check is less valuable since this workflow is primarily concerned with making sure the plugin passes PHPUnit tests.