### PR TITLE
Decouple package filename from package metadata

### DIFF
--- a/inc/default-repo/namespace.php
+++ b/inc/default-repo/namespace.php
@@ -26,7 +26,7 @@ function bootstrap() {
  */
 function get_default_repo_domain() : string {
 	if ( defined( 'FAIR_DEFAULT_REPO_DOMAIN' ) ) {
-		return FAIR_DEFAULT_REPO_DOMAIN;
+		return (string) \FAIR_DEFAULT_REPO_DOMAIN;
 	}
 
 	return 'api.aspirecloud.net';

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -731,8 +731,6 @@ function get_package_data( $did ) {
 		'author'            => $metadata->authors[0]->name,
 		'author_uri'        => $metadata->authors[0]->url,
 		'slug'              => $metadata->slug,
-		$type               => $filename,
-		'file'              => $filename,
 		'slug_didhash'      => $hashed_slug,
 		'url'               => $metadata->url ?? $metadata->slug,
 		'sections'          => $sections,

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -680,34 +680,24 @@ function get_banners( $banners ) : array {
 }
 
 /**
- * Get hashed file name from MetadataDocument.
+ * Get hashed slug from MetadataDocument.
  *
  * @param  MetadataDocument $metadata MetadataDocument.
  *
  * @return string
  */
-function get_hashed_filename( $metadata ) : string {
+function get_hashed_slug( $metadata ) : string {
 	$did_hash = '-' . get_did_hash( $metadata->id );
 
 	// Use the slug from the filename, if present.
-	list( $slug, $file ) = array_pad( explode( '/', $metadata->filename ?? '', 2 ), 2, '' );
+	list( $slug ) = array_pad( explode( '/', $metadata->filename ?? '', 2 ), 1, '' );
 	if ( '' === $slug ) {
 		$slug = $metadata->slug ?? '';
-	}
-
-	// Default to slug matching the plugin filename, if not specified.
-	if ( '' === $file ) {
-		$file = $slug . '.php';
 	}
 
 	// Append DID hash to slug if not already present.
 	if ( ! str_ends_with( $slug, $did_hash ) ) {
 		$slug .= $did_hash;
-	}
-
-	// WP plugins must include the plugin filename.
-	if ( 'wp-plugin' === ( $metadata->type ?? '' ) ) {
-		return $slug . '/' . $file;
 	}
 
 	return $slug;
@@ -731,7 +721,7 @@ function get_package_data( $did ) {
 	}
 
 	$required_versions = version_requirements( $release );
-	$filename = get_hashed_filename( $metadata );
+	$hashed_slug = get_hashed_slug( $metadata );
 	$type = str_replace( 'wp-', '', $metadata->type );
 	$sections = (array) $metadata->sections;
 	$description = trim( $sections['description'] ?? '' );
@@ -741,9 +731,9 @@ function get_package_data( $did ) {
 		'author'            => $metadata->authors[0]->name,
 		'author_uri'        => $metadata->authors[0]->url,
 		'slug'              => $metadata->slug,
-		'slug_didhash'      => $metadata->slug . '-' . get_did_hash( $did ),
 		$type               => $filename,
 		'file'              => $filename,
+		'slug_didhash'      => $hashed_slug,
 		'url'               => $metadata->url ?? $metadata->slug,
 		'sections'          => $sections,
 		'description'       => $description,
@@ -874,7 +864,7 @@ function maybe_rename_on_package_download( $source, string $remote_source, WP_Up
 		return $source;
 	}
 
-	$new_source = trailingslashit( $remote_source ) . $metadata->slug . '-' . get_did_hash( $did );
+	$new_source = trailingslashit( $remote_source ) . get_hashed_slug( $metadata );
 
 	if ( trailingslashit( strtolower( $source ) ) !== trailingslashit( strtolower( $new_source ) ) ) {
 		$wp_filesystem->move( $source, $new_source, true );
@@ -926,7 +916,7 @@ function move_package_during_install( $source, string $remote_source, WP_Upgrade
 		// Cannot guarantee a slug-didhash format. dir-didhash is the best achievable.
 		$new_source = untrailingslashit( $source ) . "-{$did_hash}/";
 	} else {
-		$new_source = dirname( untrailingslashit( $source ), 2 ) . "/{$metadata->slug}-{$did_hash}/";
+		$new_source = dirname( untrailingslashit( $source ), 2 ) . '/' . get_hashed_slug( $metadata ) . '/';
 	}
 
 	// Core must be able to find the new source directory.

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -706,7 +706,7 @@ function get_hashed_filename( $metadata ) : string {
 	}
 
 	// WP plugins must include the plugin filename.
-	if ( 'wp-plugin' === $metadata->type ?? '' ) {
+	if ( 'wp-plugin' === ( $metadata->type ?? '' ) ) {
 		return $slug . '/' . $file;
 	}
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -687,21 +687,30 @@ function get_banners( $banners ) : array {
  * @return string
  */
 function get_hashed_filename( $metadata ) : string {
-	$filename = $metadata->filename;
-	$type = str_replace( 'wp-', '', $metadata->type );
 	$did_hash = '-' . get_did_hash( $metadata->id );
 
-	list( $slug, $file ) = explode( '/', $filename, 2 );
-	if ( 'plugin' === $type ) {
-		if ( ! str_contains( $slug, $did_hash ) ) {
-			$slug .= $did_hash;
-		}
-		$filename = $slug . '/' . $file;
-	} else {
-		$filename = $slug . $did_hash;
+	// Use the slug from the filename, if present.
+	list( $slug, $file ) = array_pad( explode( '/', $metadata->filename ?? '', 2 ), 2, '' );
+	if ( '' === $slug ) {
+		$slug = $metadata->slug ?? '';
 	}
 
-	return $filename;
+	// Default to slug matching the plugin filename, if not specified.
+	if ( '' === $file ) {
+		$file = $slug . '.php';
+	}
+
+	// Append DID hash to slug if not already present.
+	if ( ! str_contains( $slug, $did_hash ) ) {
+		$slug .= $did_hash;
+	}
+
+	// WP plugins must include the plugin filename.
+	if ( 'wp-plugin' === $metadata->type ?? '' ) {
+		return $slug . '/' . $file;
+	}
+
+	return $slug;
 }
 
 /**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -721,9 +721,6 @@ function get_package_data( $did ) {
 	}
 
 	$required_versions = version_requirements( $release );
-	$hashed_slug = get_hashed_slug( $metadata );
-	$type = str_replace( 'wp-', '', $metadata->type );
-	$sections = (array) $metadata->sections;
 	$description = trim( $sections['description'] ?? '' );
 
 	$response = [
@@ -731,9 +728,9 @@ function get_package_data( $did ) {
 		'author'            => $metadata->authors[0]->name,
 		'author_uri'        => $metadata->authors[0]->url,
 		'slug'              => $metadata->slug,
-		'slug_didhash'      => $hashed_slug,
+		'slug_didhash'      => get_hashed_slug( $metadata ),
 		'url'               => $metadata->url ?? $metadata->slug,
-		'sections'          => $sections,
+		'sections'          => (array) $metadata->sections,
 		'description'       => $description,
 		'short_description' => substr( strip_tags( $description ), 0, 147 ) . '...',
 		'icons'             => isset( $release->artifacts->icon ) ? get_icons( $release->artifacts->icon ) : [],
@@ -754,7 +751,8 @@ function get_package_data( $did ) {
 		'active_installs'   => 0,
 		'_fair'             => $metadata,
 	];
-	if ( 'theme' === $type ) {
+
+	if ( 'wp-theme' === $metadata->type ) {
 		$response['theme_uri'] = $response['url'];
 	}
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -701,7 +701,7 @@ function get_hashed_filename( $metadata ) : string {
 	}
 
 	// Append DID hash to slug if not already present.
-	if ( ! str_contains( $slug, $did_hash ) ) {
+	if ( ! str_ends_with( $slug, $did_hash ) ) {
 		$slug .= $did_hash;
 	}
 

--- a/inc/packages/wp-cli/compat/namespace.php
+++ b/inc/packages/wp-cli/compat/namespace.php
@@ -8,6 +8,7 @@
 namespace FAIR\Packages\WP_CLI\Compat;
 
 use FAIR\Packages as Packages;
+use function FAIR\Updater\get_packages;
 use function WP_CLI\Utils\get_flag_value as get_flag_value;
 use WP_CLI;
 
@@ -89,13 +90,6 @@ function maybe_handle_command( array $args = [], array $assoc_args = [] ): void 
  * @return void
  */
 function handle_command( string $command, string $subcommand, array $args, array $assoc_args, array $items, array $dids ): void {
-	$hashed_items = replace_dids_with_hashed_filenames( $items, $dids );
-	if ( $hashed_items === array_values( $items ) ) {
-		return;
-	}
-
-	force_detection_by_did( $dids );
-
 	switch ( $subcommand ) {
 		case 'activate':
 		case 'deactivate':
@@ -107,7 +101,37 @@ function handle_command( string $command, string $subcommand, array $args, array
 		case 'toggle':
 		case 'uninstall':
 		case 'update':
-			$args = array_merge( [ $command, $subcommand ], $hashed_items );
+			$packages = get_packages();
+			$plugin_basename_by_did = [];
+
+			// Get the plugin basenames for the DIDs.
+			foreach ( $dids as $did ) {
+				if ( ! empty( $packages['plugins'][ $did ] ) ) {
+					$plugin_basename_by_did[ $did ] = plugin_basename( $packages['plugins'][ $did ] );
+				}
+			}
+
+			// Replace positional DIDs with plugin basenames where possible.
+			$plugin_items = array_map(
+				fn ( $item ) => $plugin_basename_by_did[ $item ] ?? $item,
+				$items
+			);
+
+			// Match DIDs to plugin information too.
+			add_filter(
+				'all_plugins',
+				function ( $all_plugins ) use ( $plugin_basename_by_did ) {
+					foreach ( $plugin_basename_by_did as $did => $plugin_file ) {
+						if ( isset( $all_plugins[ $plugin_file ] ) ) {
+							$all_plugins[ $did ] = $all_plugins[ $plugin_file ];
+						}
+					}
+
+					return $all_plugins;
+				}
+			);
+
+			$args = array_merge( [ $command, $subcommand ], $plugin_items );
 			run_command_and_halt( $args, $assoc_args );
 			break;
 		case 'search':
@@ -127,47 +151,7 @@ function handle_command( string $command, string $subcommand, array $args, array
 			WP_CLI::log( __( 'The verify-checksums command is not currently supported for DIDs.', 'fair' ) );
 			WP_CLI::halt( 1 );
 			break;
-		default:
-			// Do nothing.
-			break;
 	}
-}
-
-/**
- * Force WP to detect plugins by their DIDs.
- *
- * This adds a filter to 'all_plugins' that duplicates entries
- * for the hashed filenames to also be accessible by their DIDs.
- *
- * @param string[] $dids The DIDs to force detection for.
- * @return void
- */
-function force_detection_by_did( array $dids ): void {
-	add_filter(
-		'all_plugins',
-		function ( $all_plugins ) use ( $dids ) {
-			foreach ( $dids as $did ) {
-				$metadata = Packages\fetch_package_metadata( $did );
-				if ( is_wp_error( $metadata ) ) {
-					WP_CLI::warning(
-						sprintf(
-							/* translators: 1: The DID, 2: The error message. */
-							__( 'Could not retrieve metadata for %1$s - %2$s', 'fair' ),
-							$did,
-							$metadata->get_error_message()
-						)
-					);
-					continue;
-				}
-
-				$filename = Packages\get_hashed_filename( $metadata );
-				if ( isset( $all_plugins[ $filename ] ) ) {
-					$all_plugins[ $did ] = $all_plugins[ $filename ];
-				}
-			}
-			return $all_plugins;
-		}
-	);
 }
 
 /**
@@ -257,36 +241,4 @@ function run_command_and_halt( array $args, array $assoc_args = [] ): void {
 			WP_CLI::halt( $e->getCode() );
 		}
 	}
-}
-
-/**
- * Replace DIDs in an array of items with their hashed filenames.
- *
- * @param string[] $items The command line items.
- * @param string[] $dids  The DIDs to replace.
- * @return string[] The modified items.
- */
-function replace_dids_with_hashed_filenames( array $items, array $dids ): array {
-	return array_map(
-		function ( $item ) use ( $dids ) {
-			if ( in_array( $item, $dids, true ) ) {
-				$metadata = Packages\fetch_package_metadata( $item );
-				if ( is_wp_error( $metadata ) ) {
-					WP_CLI::warning(
-						sprintf(
-							/* translators: 1: The DID, 2: The error message. */
-							__( 'Could not retrieve metadata for %1$s - %2$s', 'fair' ),
-							$item,
-							$metadata->get_error_message()
-						)
-					);
-					return $item;
-				}
-
-				return Packages\get_hashed_filename( $metadata );
-			}
-			return $item;
-		},
-		$items
-	);
 }

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -279,8 +279,11 @@ class Updater {
 			}
 
 			$rel_path = $package->get_relative_path();
+			$meta = $package->get_metadata();
+			$package_type = str_replace( 'wp-', '', $meta->type );
 
 			$response['slug'] = $response['slug_didhash'];
+			$response[ $package_type ] = $rel_path;
 
 			$is_compatible = Packages\check_requirements( $release );
 

--- a/tests/phpstan-baseline.neon
+++ b/tests/phpstan-baseline.neon
@@ -69,7 +69,7 @@ parameters:
 		-
 			message: '#^Call to static method warning\(\) on an unknown class WP_CLI\.$#'
 			identifier: class.notFound
-			count: 3
+			count: 1
 			path: ../inc/packages/wp-cli/compat/namespace.php
 
 		-

--- a/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
+++ b/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
@@ -108,6 +108,23 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a hash-like substring in the middle of the slug still gets the DID hash appended.
+	 */
+	public function test_should_append_hash_when_same_value_appears_in_middle_of_plugin_slug() {
+		$hash = get_did_hash( 'did:plc:example1234567890123456789' );
+		$slug = 'vendor-' . $hash . '-plugin';
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => $slug . '/' . $slug . '.php',
+				'slug' => $slug,
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( $slug . '-' . $hash . '/' . $slug . '.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
 	 * Test that empty plugin filenames behave the same as missing filenames.
 	 */
 	public function test_should_fall_back_to_slug_when_plugin_filename_is_empty_string() {

--- a/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
+++ b/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
@@ -123,6 +123,23 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a missing type is treated as non-plugin metadata.
+	 *
+	 * This covers the operator precedence difference between
+	 * `'wp-plugin' === ( $metadata->type ?? '' )` and
+	 * `'wp-plugin' === $metadata->type ?? ''`.
+	 */
+	public function test_should_treat_missing_type_as_non_plugin_metadata() {
+		$metadata = (object) [
+			'id' => 'did:plc:example1234567890123456789',
+			'slug' => 'example',
+			'filename' => 'example/example.php',
+		];
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+	}
+
+	/**
 	 * Create a metadata document for testing.
 	 *
 	 * @param array $overrides Document overrides.

--- a/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
+++ b/tests/phpunit/tests/Packages/GetHashedFilenameTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for FAIR\Packages\get_hashed_filename().
+ *
+ * @package FAIR
+ */
+
+use FAIR\Packages\MetadataDocument;
+use function FAIR\Packages\get_did_hash;
+use function FAIR\Packages\get_hashed_filename;
+
+/**
+ * Tests for FAIR\Packages\get_hashed_filename().
+ *
+ * @covers FAIR\Packages\get_hashed_filename
+ */
+class GetHashedFilenameTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that plugin filenames append the DID hash to the directory name.
+	 */
+	public function test_should_hash_plugin_directory_name() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => 'example/example.php',
+				'slug' => 'example',
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that missing plugin filenames fall back to the slug.
+	 */
+	public function test_should_fall_back_to_slug_when_plugin_filename_missing() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => null,
+				'slug' => 'example',
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that malformed plugin filenames still produce a valid hashed path.
+	 */
+	public function test_should_recover_when_plugin_filename_has_no_main_file() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => 'example',
+				'slug' => 'example',
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that theme filenames append the DID hash to the slug.
+	 */
+	public function test_should_hash_theme_slug() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => 'example',
+				'slug' => 'example',
+				'type' => 'wp-theme',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that missing non-plugin filenames still fall back to the slug.
+	 */
+	public function test_should_fall_back_to_slug_for_non_plugin_when_filename_missing() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => null,
+				'slug' => 'example',
+				'type' => 'wp-theme',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that a pre-hashed plugin slug is not hashed twice.
+	 */
+	public function test_should_not_append_hash_twice_for_plugin_slug() {
+		$hash = get_did_hash( 'did:plc:example1234567890123456789' );
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => 'example-' . $hash . '/example.php',
+				'slug' => 'example-' . $hash,
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( 'example-' . $hash . '/example.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Test that empty plugin filenames behave the same as missing filenames.
+	 */
+	public function test_should_fall_back_to_slug_when_plugin_filename_is_empty_string() {
+		$metadata = $this->create_metadata_document(
+			[
+				'filename' => '',
+				'slug' => 'example',
+				'type' => 'wp-plugin',
+			]
+		);
+
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+	}
+
+	/**
+	 * Create a metadata document for testing.
+	 *
+	 * @param array $overrides Document overrides.
+	 * @return MetadataDocument
+	 */
+	private function create_metadata_document( array $overrides ) : MetadataDocument {
+		$metadata = new MetadataDocument();
+		$metadata->id = 'did:plc:example1234567890123456789';
+		$metadata->type = 'wp-plugin';
+		$metadata->slug = 'example';
+		$metadata->filename = 'example/example.php';
+
+		foreach ( $overrides as $key => $value ) {
+			$metadata->{$key} = $value;
+		}
+
+		return $metadata;
+	}
+}

--- a/tests/phpunit/tests/Packages/GetHashedPackageIdentityTest.php
+++ b/tests/phpunit/tests/Packages/GetHashedPackageIdentityTest.php
@@ -1,25 +1,25 @@
 <?php
 /**
- * Tests for FAIR\Packages\get_hashed_filename().
+ * Tests for FAIR\Packages package identity helpers.
  *
  * @package FAIR
  */
 
 use FAIR\Packages\MetadataDocument;
 use function FAIR\Packages\get_did_hash;
-use function FAIR\Packages\get_hashed_filename;
+use function FAIR\Packages\get_hashed_slug;
 
 /**
- * Tests for FAIR\Packages\get_hashed_filename().
+ * Tests for FAIR\Packages package identity helpers.
  *
- * @covers FAIR\Packages\get_hashed_filename
+ * @covers FAIR\Packages\get_hashed_slug
  */
-class GetHashedFilenameTest extends WP_UnitTestCase {
+class GetHashedPackageIdentityTest extends WP_UnitTestCase {
 
 	/**
-	 * Test that plugin filenames append the DID hash to the directory name.
+	 * Test that hashed slugs stay decoupled from the plugin bootstrap filename.
 	 */
-	public function test_should_hash_plugin_directory_name() {
+	public function test_should_return_hashed_slug_for_plugin_metadata() {
 		$metadata = $this->create_metadata_document(
 			[
 				'filename' => 'example/example.php',
@@ -28,26 +28,26 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
-	 * Test that missing plugin filenames fall back to the slug.
+	 * Test that plugin slugs hash independently of the bootstrap filename.
 	 */
-	public function test_should_fall_back_to_slug_when_plugin_filename_missing() {
+	public function test_should_ignore_plugin_bootstrap_filename_when_hashing_slug() {
 		$metadata = $this->create_metadata_document(
 			[
-				'filename' => null,
+				'filename' => 'example/custom-bootstrap.php',
 				'slug' => 'example',
 				'type' => 'wp-plugin',
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
-	 * Test that malformed plugin filenames still produce a valid hashed path.
+	 * Test that malformed plugin filenames still produce a valid hashed slug.
 	 */
 	public function test_should_recover_when_plugin_filename_has_no_main_file() {
 		$metadata = $this->create_metadata_document(
@@ -58,11 +58,11 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
-	 * Test that theme filenames append the DID hash to the slug.
+	 * Test that theme slugs append the DID hash.
 	 */
 	public function test_should_hash_theme_slug() {
 		$metadata = $this->create_metadata_document(
@@ -73,7 +73,7 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
@@ -104,7 +104,7 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . $hash . '/example.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . $hash, get_hashed_slug( $metadata ) );
 	}
 
 	/**
@@ -121,11 +121,11 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( $slug . '-' . $hash . '/' . $slug . '.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( $slug . '-' . $hash, get_hashed_slug( $metadata ) );
 	}
 
 	/**
-	 * Test that empty plugin filenames behave the same as missing filenames.
+	 * Test that empty plugin filenames behave the same as missing filenames for slug hashing.
 	 */
 	public function test_should_fall_back_to_slug_when_plugin_filename_is_empty_string() {
 		$metadata = $this->create_metadata_document(
@@ -136,7 +136,7 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ) . '/example.php', get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**
@@ -153,7 +153,7 @@ class GetHashedFilenameTest extends WP_UnitTestCase {
 			'filename' => 'example/example.php',
 		];
 
-		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_filename( $metadata ) );
+		$this->assertSame( 'example-' . get_did_hash( $metadata->id ), get_hashed_slug( $metadata ) );
 	}
 
 	/**


### PR DESCRIPTION
Filename is a dynamic property that WP resolves during runtime. It shouldn't be part of package metadata.

1. During **an update** WP already knows the plugin bootstrap (basename) file from the option: https://github.com/WordPress/wordpress-develop/blob/5a96ff4d54a97955b02ac3c20f3ae7f21185232f/src/wp-includes/update.php#L570

2. And during **a fresh plugin install** it resolves it by scanning all PHP files in the root of newly installed plugin for the header: https://github.com/WordPress/wordpress-develop/blob/5a96ff4d54a97955b02ac3c20f3ae7f21185232f/src/wp-admin/includes/plugin-install.php#L469
