### PR TITLE
Ensure the correct cache type for DID document

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -155,7 +155,7 @@ function get_did_document( string $id ) {
 	}
 
 	$cached = get_site_transient( CACHE_METADATA_DOCUMENTS . $id );
-	if ( $cached ) {
+	if ( $cached && is_array( $cached ) ) {
 		return $cached;
 	}
 


### PR DESCRIPTION
Fixes #503.

- Ignore cache if not an `array` type.

I also confirmed that none of the other cache values were updated to a different type so this should be the only case we need to fix.