### PR TITLE
Allow installing via Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,6 @@
 phpunit.xml.dist export-ignore
 wp-tests-config-sample.php export-ignore
 phpcs.xml.dist export-ignore
-composer.json export-ignore
-composer.lock export-ignore
 package.json export-ignore
 package-lock.json export-ignore
 .wp-env.json export-ignore

--- a/plugin.php
+++ b/plugin.php
@@ -25,7 +25,11 @@ const VERSION = '1.4.0';
 const PLUGIN_DIR = __DIR__;
 const PLUGIN_FILE = __FILE__;
 
-require_once __DIR__ . '/vendor/autoload.php';
+// Use local autoload if available.
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/avatars/namespace.php';
 require_once __DIR__ . '/inc/credits/namespace.php';


### PR DESCRIPTION
Fixes #505.

Although Composer install is not the primary way of installing this plugin (and it also somewhat contradicts the primary use-case), it would be great to allow this method for testing and automation reasons.

1. Ensure that both `composer.json` and `composer.lock` are included in the GitHub release artifacts.

2. Load the local `vendor/autoload.php` only if present.