### PR TITLE
Remove leftover `( new Updater\Updater( $did ) )->run();` call during DID ajax install

### DIFF
--- a/inc/packages/admin/namespace.php
+++ b/inc/packages/admin/namespace.php
@@ -124,8 +124,6 @@ function handle_did_during_ajax( $result, $action, $args ) {
 		return $result;
 	}
 
-	( new Updater\Updater( $did ) )->run();
-
 	Packages\add_package_to_release_cache( $did );
 	add_filter( 'http_request_args', 'FAIR\\Packages\\maybe_add_accept_header', 20, 2 );
 

--- a/tests/phpstan-baseline.neon
+++ b/tests/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: ../inc/packages/admin/namespace.php
 
 		-
-			message: '#^Class FAIR\\Updater\\Updater does not have a constructor and must be instantiated without any parameters\.$#'
-			identifier: new.noConstructor
-			count: 1
-			path: ../inc/packages/admin/namespace.php
-
-		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 1


### PR DESCRIPTION
Fixes #507.