### PR TITLE
Trivial tweaks to inc/packages/namespace.php

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -346,7 +346,7 @@ function pick_release( array $releases, ?string $version = null ) : ?ReleaseDocu
 
 	// If no version is specified, return the latest release.
 	if ( empty( $version ) ) {
-		return reset( $releases );
+		return reset( $releases ) ?: null;
 	}
 
 	return array_find( $releases, fn ( $release ) => $release->version === $version );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -35,7 +35,10 @@ const SERVICE_ID = 'FairPackageManagementRepo';
 function get_plc_client(): PlcClient {
 	static $client;
 	if ( ! $client ) {
-		$client = new PlcClient();
+		$base_url = defined( 'FAIR_PLC_DIRECTORY_URL' )
+			? FAIR_PLC_DIRECTORY_URL
+			: 'https://plc.directory';
+		$client = new PlcClient( $base_url );
 	}
 	return $client;
 }


### PR DESCRIPTION
First one makes the plc.directory url configurable.  This is already used in the `test_the_things` branch to set up a mock PLC server so we don't have to mock the http transport itself.

Second one fixes a crash if someone passes an empty versions list to `pick_release`, since `reset([])` returns false (btw  have I mentioned what a fractal of bad design `reset` is?)
