### PR TITLE
Rename to `fairpm/fair-connect` in `composer.json` for publishing to packagist.org

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,6 @@
 phpunit.xml.dist export-ignore
 wp-tests-config-sample.php export-ignore
 phpcs.xml.dist export-ignore
-composer.json export-ignore
-composer.lock export-ignore
 package.json export-ignore
 package-lock.json export-ignore
 .wp-env.json export-ignore

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fairpm/fair-plugin",
+    "name": "fairpm/fair-connect",
     "description": "Make your site more FAIR.",
     "type": "wordpress-plugin",
     "license": "gpl-2.0-only",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2d9bb03b2d90fcb6fe7a5842ae3c5a0",
+    "content-hash": "c61d31ba5bddcaea5d7e5b237c0da593",
     "packages": [
         {
             "name": "afragen/wordpress-plugin-readme-parser",


### PR DESCRIPTION
Fixes #513.

Previously the tag ZIPs on GitHub excluded the `composer.*` files so it was impossible to install the plugin using composer and this GitHub repository as the `vcs` repository, as described in #506.