### PR TITLE
fix missing key warning

### DIFF
--- a/inc/dashboard-widgets/namespace.php
+++ b/inc/dashboard-widgets/namespace.php
@@ -135,7 +135,7 @@ function get_community_events() {
 			'end_unix_timestamp' => $end,
 			'location' => [
 				'location' => $loc_name,
-				'country' => $event['camp_map_location'] ? $event['camp_map_location']['country_short'] : '',
+				'country' => $event['camp_map_location']['country_short'] ?? '',
 				'latitude' => $event['camp_lat'] ?? 0,
 				'longitude' => $event['camp_lng'] ?? 0,
 			],


### PR DESCRIPTION
`[01-Aug-2026 15:29:20 UTC] PHP Warning Undefined array key "country_short" in /sites/test.thefragens.net/files/wp-content/plugins/fair-plugin/inc/dashboard-widgets/namespace.php on line 138`

This PR should fix.